### PR TITLE
Bugfix with clams.source.PipelineSource.__init__()

### DIFF
--- a/clams/source/__init__.py
+++ b/clams/source/__init__.py
@@ -2,7 +2,7 @@ import json
 import itertools
 from typing import Union, Generator, List, Optional, Iterable
 
-from mmif import Mmif, Document
+from mmif import Mmif, Document, __specver__
 from mmif.serialize.mmif import MmifMetadata
 
 
@@ -48,7 +48,10 @@ class PipelineSource:
                                                else document
                                                for document in common_documents_json],
                                  "views": [],
-                                 "metadata": common_metadata_json}
+                                 "metadata": {
+                                     "mmif": f"http://mmif.clams.ai/{__specver__}",
+                                     **common_metadata_json
+                                 }}
         self.prime()
 
     def add_document(self, document: Union[str, dict, Document]) -> None:

--- a/clams/source/__init__.py
+++ b/clams/source/__init__.py
@@ -39,6 +39,10 @@ class PipelineSource:
             common_documents_json: Optional[List[DOC_JSON]] = None,
             common_metadata_json: Optional[METADATA_JSON] = None
     ) -> None:
+        if common_documents_json is None:
+            common_documents_json = []
+        if common_metadata_json is None:
+            common_metadata_json = dict()
         self.mmif_start: dict = {"documents": [json.loads(document)
                                                if isinstance(document, str)
                                                else document


### PR DESCRIPTION
Code was trying to iterate over `None` from the default parameters. Method now replaces the value of `common_documents_json` with `[]` if it is `None`, and replaces the value of `common_metadata_json` with `dict()` if it is `None`.

Default `metadata` in `self.mmif_start` now includes `"mmif": f"http://mmif.clams.ai/{__specver__}"`, which will be overwritten by any user-defined value for `metadata["mmif"]`.