### PR TITLE
Add 'clams' CLI utility and implement 'clams source' action

### DIFF
--- a/clams/__init__.py
+++ b/clams/__init__.py
@@ -1,3 +1,25 @@
+from typing import Dict, Type
+
 from clams.serve import *
+from clams.serve import __all__ as serve_all
 from clams.restify import Restifier
-from clams.source import PipelineSource
+from clams.source import PipelineSource, SourceCli
+from clams.utils import Cli
+
+
+__all__ = ['Restifier', 'PipelineSource'] + serve_all
+
+
+CLIS: Dict[str, Type[Cli]] = {
+    'source': SourceCli
+}
+
+
+def cli():
+    import argparse
+    import sys
+    parser = argparse.ArgumentParser()
+    parser.add_argument('verb', type=str, choices=['source'])
+    args = parser.parse_args(sys.argv[1:2])
+    if args.verb:
+        CLIS[args.verb]().run()

--- a/clams/utils/__init__.py
+++ b/clams/utils/__init__.py
@@ -1,0 +1,10 @@
+import sys
+import abc
+
+
+class Cli(abc.ABC):
+    def __init__(self):
+        self.args = sys.argv[2:]
+
+    def run(self):
+        raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,10 @@ setuptools.setup(
     ],
     install_requires=requires,
     python_requires='>=3.6',
-    packages=setuptools.find_packages() 
+    packages=setuptools.find_packages(),
+    entry_points={
+        'console_scripts': [
+            'clams = clams.__init__:cli',
+        ],
+    },
 )


### PR DESCRIPTION
Arguments to `clams source` should be colon-joined pairs of MIME types and filepaths. The output will be a MMIF file containing a document for each of those filepaths, with the appropriate `@type` and MIME type, printed to the standard output.

Top-level MIME types should be one of `audio`, `video`, `text`, and `image`. Subtypes, such as `video/mpeg`, are permitted.

For example:
```
$ clams source video/mpeg:/var/archive/video-002.mp4 text:/var/archive/transcript-002.txt
{
  "metadata": {
    "mmif": "http://mmif.clams.ai/0.2.1"
  },
  "documents": [
    {
      "@type": "http://mmif.clams.ai/0.2.1/vocabulary/VideoDocument",
      "properties": {
        "mime": "video/mpeg",
        "location": "/var/archive/video-002.mp4",
        "id": "d1"
      }
    },
    {
      "@type": "http://mmif.clams.ai/0.2.1/vocabulary/TextDocument",
      "properties": {
        "mime": "text",
        "location": "/var/archive/transcript-002.txt",
        "id": "d2"
      }
    }
  ]
}
```
Note that this currently outputs invalid MMIF, due to the absence of a `views` attribute. This is being addressed in [clamsproject/mmif #122](https://github.com/clamsproject/mmif/issues/122).