### PR TITLE
Adding appmetadata schema

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,11 +16,8 @@ jobs:
     - name: Run test and generate coverage report
       working-directory: .
       run: |
-        pip install -r requirements.txt
-        pip install -r requirements.dev
         echo "codecov.dev" > VERSION
-        python setup.py sdist
-        python -m pytest --doctest-modules --cov=clams/ --cov-report=xml
+        make test
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,19 +20,10 @@ jobs:
         echo "VERSION=$(echo "${{ github.ref }}" | cut -d/ -f3)" >> $GITHUB_ENV
     - name: build a sdist
       run: |
-        pip install -r requirements.dev
-        pip install -r requirements.txt
-        echo ${{ env.VERSION }} > VERSION
-        python setup.py sdist
-        python -m pytest --doctest-modules --cov=clams/ --cov-report=xml
+        make package
     - name: build HTML documentation 
       run: |
-        pip install -r requirements.dev
-        python setup.py build_sphinx -a
-        rm -rf docs
-        mv documentation/_build/html docs
-        echo 'sdk.clams.ai' > docs/CNAME
-        touch docs/.nojekyll
+        make docs
     - name: configure clamsbot git user
       run: |
         git config --local user.email "admin@clams.ai"

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ hs_err_pid* # virtual machine crash logs, see http://www.java.com/en/download/he
 build/
 dist/
 *.egg-info
+coverage.xml
 
 # shared folders
 dropbox_shared*/

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ check_deps := $(foreach dep,$(deps), $(if $(shell which $(dep)),some string,$(er
 
 # constants
 packagename = clams
+generatedcode = $(packagename)/ver
 sdistname = $(packagename)-python
 bdistname = $(packagename)_python
 artifact = build/lib/$(packagename)
 buildcaches = build/bdist* $(bdistname).egg-info __pycache__
 testcaches = .hypothesis .pytest_cache .pytype coverage.xml htmlcov .coverage
-generatedcode = clams/ver
 
 .PHONY: all
 .PHONY: clean
@@ -29,39 +29,36 @@ develop: devversion package test
 	twine upload --repository-url http://morbius.cs-i.brandeis.edu:8081/repository/pypi-develop/ \
 		-u clamsuploader -p $$CLAMSUPLOADERPASSWORD dist/$(sdistname)-`cat VERSION`.tar.gz
 
-publish: clean version package test 
+publish: distclean version package test 
 	test `git branch --show-current` = "master"
 	@git tag `cat VERSION` 
 	@git push origin `cat VERSION`
 
-clams/ver: 
+$(generatedcode): VERSION
 	python3 setup.py donothing
 
-docs: dist
-	pip install -r requirements.dev
+docs: VERSION $(generatedcode)
 	rm -rf documentation/_build docs
-	rm -rf docs
 	python3 setup.py build_sphinx -a
 	mv documentation/_build/html docs
-	python3 clams/appmetadata/__init__.py > docs/appmetadata.jsonschema
-	echo 'sdk.clams.ai' > docs/CNAME
 	touch docs/.nojekyll
+	echo 'sdk.clams.ai' > docs/CNAME
+	python3 clams/appmetadata/__init__.py > docs/appmetadata.jsonschema
 
-dist: package 
-package: VERSION coverage.xml
+package: VERSION
+	pip install --upgrade -r requirements.dev
 	python3 setup.py sdist
 
 build: $(artifact)
 $(artifact):
 	python3 setup.py build
 
-coverage.xml: test 
 # invoking `test` without a VERSION file will generated a dev version - this ensures `make test` runs unmanned
 test: devversion $(generatedcode)
-	pip install -r requirements.dev
+	pip install --upgrade -r requirements.dev
 	pip install -r requirements.txt
 	pytype $(packagename)
-	python3 -m pytest --doctest-modules --cov=$(packagename) --cov-report=xml
+	python3 -m pytest --cov=$(packagename) --cov-report=xml
 
 # helper functions
 e :=
@@ -79,7 +76,7 @@ increase_dev = $(call macro,$(1)).$(call micro,$(1)).$(call patch,$(1)).dev$$(($
 devversion: VERSION.dev VERSION; cat VERSION
 version: VERSION; cat VERSION
 
-VERSION.dev: devver := $(shell curl -s -X GET 'http://morbius.cs-i.brandeis.edu:8081/service/rest/v1/search?name=$(sdistname)' | jq '. | .items[].version' -r | sort | tail -n 1)
+VERSION.dev: devver := $(shell curl -s -X GET 'http://morbius.cs-i.brandeis.edu:8081/service/rest/v1/search?name=$(sdistname)' | jq '. | .items[].version' -r | sort -V | tail -n 1)
 VERSION.dev:
 	if [[ $(devver) == *.dev* ]]; then echo $(call increase_dev,$(devver)) ; else echo $(call add_dev,$(call increase_patch, $(devver))); fi \
 	> VERSION.dev
@@ -93,6 +90,6 @@ VERSION:
 	fi
 
 distclean:
-	@rm -rf dist $(artifact) build/bdist* 
+	@rm -rf dist $(artifact) build/bdist*
 clean: distclean
 	@rm -rf VERSION VERSION.dev $(testcaches) $(buildcaches) $(generatedcode)

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,12 @@ $(generatedcode): VERSION
 
 docs: VERSION $(generatedcode)
 	rm -rf documentation/_build docs
+	python3 clams/appmetadata/__init__.py > documentation/appmetadata.jsonschema
 	python3 setup.py build_sphinx -a
 	mv documentation/_build/html docs
+	mv documentation/appmetadata.jsonschema docs/
 	touch docs/.nojekyll
 	echo 'sdk.clams.ai' > docs/CNAME
-	python3 clams/appmetadata/__init__.py > docs/appmetadata.jsonschema
 
 package: VERSION
 	pip install --upgrade -r requirements.dev

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -118,8 +118,8 @@ class ClamsApp(ABC):
         """
         if view.is_frozen():
             raise ValueError("can't modify an old view")
-        view.metadata['app'] = self.metadata['iri']
-        view.metadata['parameter'] = runtime_params
+        view.metadata.app = self.metadata.identifier
+        view.metadata.parameter = runtime_params
         
     def record_error(self, mmif: Union[str, dict, Mmif], runtime_params: dict) -> Mmif:
         """
@@ -140,7 +140,7 @@ class ClamsApp(ABC):
             mmif = Mmif(mmif)
         error_view = None
         for view in reversed(mmif.views):
-            if view.metadata.app == self.metadata['iri']:
+            if view.metadata.app == self.metadata.identifier:
                 error_view = view
                 error_view.metadata.contains = {}
                 error_view.annotations._items = {}

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -48,7 +48,7 @@ class ClamsApp(ABC):
         An abstract method to set up input specification for this app. All CLAMS
         app must implement this.
         
-        :return: a list of ``Input`` objects
+        :return: a list of :class:`~clams.appmetadata.Input` objects
         """
         raise NotImplementedError()
 
@@ -58,7 +58,7 @@ class ClamsApp(ABC):
         An abstract method to set up output specification for this app. All CLAMS
         app must implement this.
         
-        :return: a list of ``Output`` objects
+        :return: a list of :class:`~clams.appmetadata.Output` objects
         """
         raise NotImplementedError()
 
@@ -66,9 +66,10 @@ class ClamsApp(ABC):
     def _appmetadata(self) -> AppMetadata:
         """
         An abstract method to generate (or load if stored elsewhere) the app metadata
-        at runtime. All CLAMS app must implement this. Note that ``input`` and 
-        ``output`` fields must be implemented separately via :func:`_input_spec` 
-        and :func:`_output_spec` respectively. That is, this method should only 
+        at runtime. All CLAMS app must implement this. For metadata specification, 
+        see `https://sdk.clams.ai/appmetadata.jsonschema <../appmetadata.jsonschema>`_. Note that ``input`` 
+        and ``output`` fields must be implemented separately via :func:`~clams.app.ClamsApp._input_spec` 
+        and :func:`~clams.app.ClamsApp._output_spec` respectively. That is, this method should only 
         populate basic app information on the top-level of the schema. 
 
         :return: A Python object of the metadata, must be JSON-serializable

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -27,7 +27,7 @@ class ClamsApp(ABC):
         self.annotate_param_spec = {'pretty': bool}
         python_type = {"boolean": bool, "number": float, "integer": int, "string": str}
         for param_spec in self.metadata.parameters:
-            self.annotate_param_spec[param_spec.name] = python_type[param_spec.value.datatype]
+            self.annotate_param_spec[param_spec.name] = python_type[param_spec.type]
 
     def appmetadata(self, **kwargs) -> str:
         """

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -36,13 +36,11 @@ class ClamsApp(ABC):
         """
         self.metadata.input = self.input_spec
         self.metadata.output = self.output_spec
-        if isinstance(self.metadata, AppMetadata):
-            self.metadata = self.metadata.dict(exclude_unset=True, by_alias=True)
         pretty = kwargs.pop('pretty') if 'pretty' in kwargs else False
         if pretty:
-            return json.dumps(self.metadata, indent=4)
+            return self.metadata.json(exclude_unset=True, by_alias=True, indent=2)
         else:
-            return json.dumps(self.metadata)
+            return self.metadata.json(exclude_unset=True, by_alias=True)
 
     @abstractmethod
     def _input_spec(self) -> List['Input']:

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -10,6 +10,7 @@ __all__ = ['ClamsApp']
 from typing import Union, Any
 
 from mmif import Mmif, Document, DocumentTypes, View
+from clams.appmetadata import AppMetadata
 
 
 class ClamsApp(ABC):
@@ -21,7 +22,7 @@ class ClamsApp(ABC):
     def __init__(self):
         # TODO (krim @ 10/9/20): eventually we might end up with a python class
         # for this metadata (with a JSON schema)
-        self.metadata: dict = self._appmetadata()
+        self.metadata: Union[dict, AppMetadata] = self._appmetadata()
         super().__init__()
         # data type specification for common parameters
         self.metadata_param_spec = {'pretty': bool}
@@ -35,6 +36,8 @@ class ClamsApp(ABC):
         """
         # TODO (krim @ 10/9/20): when self.metadata is no longer a `dict`
         # this method might needs to be changed to properly serialize input
+        if isinstance(self.metadata, AppMetadata):
+            self.metadata = self.metadata.dict(exclude_unset=True)
         pretty = kwargs.pop('pretty') if 'pretty' in kwargs else False
         if pretty:
             return json.dumps(self.metadata, indent=4)
@@ -42,7 +45,7 @@ class ClamsApp(ABC):
             return json.dumps(self.metadata)
 
     @abstractmethod
-    def _appmetadata(self) -> dict:
+    def _appmetadata(self) -> Union[dict, AppMetadata]:
         """
         An abstract method to generate (or load if stored elsewhere) the app metadata
         at runtime. All CLAMS app must implement this.

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -37,9 +37,9 @@ class ClamsApp(ABC):
         """
         pretty = kwargs.pop('pretty') if 'pretty' in kwargs else False
         if pretty:
-            return self.metadata.json(exclude_unset=True, by_alias=True, indent=2)
+            return self.metadata.json(exclude_defaults=True, by_alias=True, indent=2)
         else:
-            return self.metadata.json(exclude_unset=True, by_alias=True)
+            return self.metadata.json(exclude_defaults=True, by_alias=True)
 
     @abstractmethod
     def _appmetadata(self) -> AppMetadata:

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -1,0 +1,42 @@
+from typing import Optional, Union
+
+import mmif
+import pydantic
+
+import clams
+
+primitives = Union[int, str, bool]
+
+
+class InputSpec(pydantic.BaseModel):
+    input: list = []
+
+
+class OutputSpec(pydantic.BaseModel):
+    output: list = []
+
+
+class AppMetadata(pydantic.BaseModel):
+    name: str
+    description: str
+    app_version: str
+    mmif_version: str = mmif.__version__
+    wrapper_version: Optional[str]
+    license: str
+    wrapper_license: Optional[str]
+    url: pydantic.AnyHttpUrl
+    input_spec: "InputSpec"
+    output_spec: "OutputSpec"
+
+    class Config:
+        title = "CLAMS AppMetadata"
+        description = "CLAMS AppMetadata defines metadata model that describes a CLAMS app"
+        extra = 'forbid'
+        allow_population_by_field_name = True
+        schema_extra = {
+            '$schema' : "http://json-schema.org/draft-07/schema#", # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
+            '$comment' : f"clams-python SDK {clams.__version__} was used to generate this schema" # this is only to hold version information
+        }
+
+if __name__ == '__main__':
+    print(AppMetadata.schema_json(indent=2))

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -51,7 +51,7 @@ class AppMetadata(pydantic.BaseModel):
     wrapper_version: Optional[str]
     license: str
     wrapper_license: Optional[str]
-    url: pydantic.AnyHttpUrl
+    identifier: pydantic.AnyHttpUrl
     input: List[Input]
     output: List[Output]
 

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -9,6 +9,9 @@ primitives = Union[int, str, bool]
 
 
 class AppMetadata(pydantic.BaseModel):
+    """
+    CLAMS AppMetadata defines metadata model that describes a CLAMS app
+    """
     name: str
     description: str
     app_version: str
@@ -22,13 +25,16 @@ class AppMetadata(pydantic.BaseModel):
 
     class Config:
         title = "CLAMS AppMetadata"
-        description = "CLAMS AppMetadata defines metadata model that describes a CLAMS app"
         extra = 'forbid'
         allow_population_by_field_name = True
-        schema_extra = {
-            '$schema': "http://json-schema.org/draft-07/schema#", # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
-            '$comment': f"clams-python SDK {clams.__version__} was used to generate this schema" # this is only to hold version information
-        }
+
+        @staticmethod
+        def schema_extra(schema, model) -> None:
+            for prop in schema.get('properties', {}).values():
+                prop.pop('title', None)
+            schema['$schema'] = "http://json-schema.org/draft-07/schema#"  # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
+            schema['$comment'] = f"clams-python SDK {clams.__version__} was used to generate this schema"  # this is only to hold version information
+
 
 if __name__ == '__main__':
     print(AppMetadata.schema_json(indent=2))

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -78,7 +78,12 @@ class RuntimeParameter(_BaseModel):
         
 class AppMetadata(pydantic.BaseModel):
     """
-    Defines a data model that describes a CLAMS app
+    Defines a data model that describes a CLAMS app. 
+    Can be initialized by simply passing all required key-value pairs. If you 
+    have a pre-generated metadata as an external file, you can read in the file 
+    as a ``dict`` and use it as keyword arguments for initialization. 
+    
+    Please refer to <:ref:`appmetadata`> for the metadata specification. 
     """
     name: str = pydantic.Field(..., description="A short name of the app.")
     description: str = pydantic.Field(..., description="A longer description of the app (what it does, how to use, etc.).")
@@ -105,6 +110,13 @@ class AppMetadata(pydantic.BaseModel):
             schema['$comment'] = f"clams-python SDK {clams.__version__} was used to generate this schema"  # this is only to hold version information
         
     def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = True, **properties):
+        """
+        Helper method to add an element to the ``input`` list. 
+        
+        :param at_type: ``@type`` of the input object
+        :param required: whether this type is mandatory or optional 
+        :param properties: additional property specifications
+        """
         new_inp = Input(at_type=at_type, required=required)
         if len(properties) > 0:
             new_inp.properties = properties
@@ -116,6 +128,12 @@ class AppMetadata(pydantic.BaseModel):
                 pass
         
     def add_output(self, at_type: Union[str, vocabulary.ThingTypesBase], **properties):
+        """
+        Helper method to add an element to the ``output`` list. 
+        
+        :param at_type: ``@type`` of the input object
+        :param properties: additional property specifications
+        """
         if at_type not in [output.at_type for output in self.output]:
             if len(properties) > 0:
                 self.output.append(Output(at_type=str(at_type), properties=dict(properties)))
@@ -125,6 +143,11 @@ class AppMetadata(pydantic.BaseModel):
             raise ValueError(f"output '{at_type}' already exist.")
     
     def add_parameter(self, **parameter_spec):
+        """
+        Helper method to add an element to the ``parameters`` list. 
+        
+        :param parameter_spec: key-value pairs that specify a RuntimeParameter. See ``RuntimeParameter`` section of <:ref:`appmetadata`> for keys and values that are accepted.
+        """
         new_param = RuntimeParameter(**parameter_spec)
         if new_param.name not in [param.name for param in self.parameters]:
             self.parameters.append(new_param)

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -19,7 +19,7 @@ class BaseModel(pydantic.BaseModel):
                 prop.pop('title', None)
 
 
-class Output(BaseModel):
+class _Output(BaseModel):
     """
     Defines a data model that describes output specification of a CLAMS app
     """
@@ -41,7 +41,7 @@ class Output(BaseModel):
         allow_population_by_field_name = True
 
                 
-class Input(Output):
+class _Input(_Output):
     """
     Defines a data model that describes input specification of a CLAMS app
     """
@@ -58,7 +58,7 @@ class Input(Output):
         allow_population_by_field_name = True
 
 
-class RuntimeParameter(BaseModel):
+class _RuntimeParameter(BaseModel):
     """
     Defines a data model that describes a single runtime configuration of a CLAMS app. 
     Usually, an app keeps a list of these configuration specifications in the 
@@ -87,9 +87,9 @@ class AppMetadata(pydantic.BaseModel):
     license: str
     wrapper_license: Optional[str]
     identifier: pydantic.AnyHttpUrl
-    input: List[Input] = None
-    output: List[Output] = None
-    parameters: List[RuntimeParameter] = None
+    input: List[_Input] = None
+    output: List[_Output] = None
+    parameters: List[_RuntimeParameter] = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -114,7 +114,7 @@ class AppMetadata(pydantic.BaseModel):
             schema['$comment'] = f"clams-python SDK {clams.__version__} was used to generate this schema"  # this is only to hold version information
         
     def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = True, **properties):
-        new_inp = Input(at_type=at_type, required=required)
+        new_inp = _Input(at_type=at_type, required=required)
         if len(properties) > 0:
             new_inp.properties = properties
         if new_inp not in self.input:
@@ -127,14 +127,14 @@ class AppMetadata(pydantic.BaseModel):
     def add_output(self, at_type: Union[str, vocabulary.ThingTypesBase], **properties):
         if at_type not in [output.at_type for output in self.output]:
             if len(properties) > 0:
-                self.output.append(Output(at_type=str(at_type), properties=dict(properties)))
+                self.output.append(_Output(at_type=str(at_type), properties=dict(properties)))
             else:
-                self.output.append(Output(at_type=str(at_type)))
+                self.output.append(_Output(at_type=str(at_type)))
         else:
             raise ValueError(f"output '{at_type}' already exist.")
     
     def add_parameter(self, **parameter_spec):
-        new_param = RuntimeParameter(**parameter_spec)
+        new_param = _RuntimeParameter(**parameter_spec)
         if new_param.name not in [param.name for param in self.parameters]:
             self.parameters.append(new_param)
         else:

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -1,12 +1,14 @@
 from typing import Optional, Union, Dict, List
-from typing_extensions import Literal
 
 import mmif
 import pydantic
+from mmif import vocabulary
+from typing_extensions import Literal
 
 import clams
 
 primitives = Union[int, float, str, bool]
+param_value_types = Literal['integer', 'number', 'string', 'boolean']
 
 
 class BaseModel(pydantic.BaseModel):
@@ -50,7 +52,7 @@ class RuntimeParameterValue(BaseModel):
     Defines a data model that describes a value of a runtime parameter. 
     """
     # these names are taken from the JSON schema data types
-    datatype: Literal['integer', 'number', 'string', 'boolean']
+    datatype: param_value_types
     choices: List[primitives]
     default: Optional[primitives] = None
     
@@ -62,7 +64,7 @@ class RuntimeParameter(BaseModel):
     ``parameters`` field. 
     """
     name: str
-    values: RuntimeParameterValue
+    value: RuntimeParameterValue
     description: str
     
     class Config:
@@ -82,9 +84,9 @@ class AppMetadata(pydantic.BaseModel):
     license: str
     wrapper_license: Optional[str]
     identifier: pydantic.AnyHttpUrl
-    input: List[Input]
-    output: List[Output]
-    parameters: List[RuntimeParameter]
+    input: List[Input] = []
+    output: List[Output] = []
+    parameters: List[RuntimeParameter] = []
 
     class Config:
         title = "CLAMS AppMetadata"
@@ -97,7 +99,39 @@ class AppMetadata(pydantic.BaseModel):
                 prop.pop('title', None)
             schema['$schema'] = "http://json-schema.org/draft-07/schema#"  # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
             schema['$comment'] = f"clams-python SDK {clams.__version__} was used to generate this schema"  # this is only to hold version information
-
+        
+    def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = False, **properties):
+        if at_type not in [input.at_type for input in self.input]:
+            self.input.append(Input(at_type=str(at_type), required=required, properties=dict(properties)))
+            if required:
+                # TODO (krim @ 5/12/21): add this *optional* input to parameter
+                # see https://github.com/clamsproject/clams-python/issues/29 for discussion
+                pass
+        
+    def add_output(self, at_type: Union[str, vocabulary.ThingTypesBase], **properties):
+        if at_type not in [output.at_type for output in self.output]:
+            self.output.append(Output(at_type=str(at_type), properties=dict(properties)))
+    
+    def add_parameter(self, name: str, description: str, value_spec: Union[dict, RuntimeParameterValue]):
+        if type(value_spec) == dict:
+            value_spec = RuntimeParameterValue(**value_spec)
+        if name not in [param.name for param in self.parameters]:
+            self.parameters.append(RuntimeParameter(name=name, description=description, value=value_spec))
+        else:
+            raise ValueError('name alredy exist')
 
 if __name__ == '__main__':
-    print(AppMetadata.schema_json(indent=2))
+    # print(AppMetadata.schema_json(indent=2))
+    r_dict = {'datatype': 'string', 'choices': ['aa', 'bb'], 'default': None}
+    r = RuntimeParameterValue(**r_dict)
+    print(r)
+    rr = RuntimeParameter(name='tmp', description='string', value=r_dict)
+    print(rr)
+    rr = RuntimeParameter(name='tmp', description='string', value=r)
+    print(rr)
+    m = AppMetadata(name='test', description='test app metadata', app_version='0.0.1', license='mit', identifier='https://google.com')
+    m.add_parameter(name='tmp', description='aaa', value_spec=r_dict)
+    print(m)
+    m.add_parameter(name='tmp2', description='aaa', value_spec=r)
+    print(m.json(indent=2))
+

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Dict, List
 
 import mmif
 import pydantic
@@ -8,9 +8,41 @@ import clams
 primitives = Union[int, str, bool]
 
 
+class Output(pydantic.BaseModel):
+    """
+    Defines a data model that describes output specification of a CLAMS app
+    """
+    at_type: pydantic.AnyHttpUrl = pydantic.Field(
+        None,
+        alias="@type"
+    )
+    properties: Optional[Dict[str, str]]
+    
+    class Config:
+        title = 'CLAMS Output Specification'
+        extra = 'forbid'
+        allow_population_by_field_name = True
+
+        def schema_extra(schema, model) -> None:
+            for prop in schema.get('properties', {}).values():
+                prop.pop('title', None)
+                
+                
+class Input(Output):
+    """
+    Defines a data model that describes input specification of a CLAMS app
+    """
+    required: Optional[bool] = True
+
+    class Config:
+        title = 'CLAMS Input Specification'
+        extra = 'forbid'
+        allow_population_by_field_name = True
+
+
 class AppMetadata(pydantic.BaseModel):
     """
-    CLAMS AppMetadata defines metadata model that describes a CLAMS app
+    Defines a data model that describes a CLAMS app
     """
     name: str
     description: str
@@ -20,8 +52,8 @@ class AppMetadata(pydantic.BaseModel):
     license: str
     wrapper_license: Optional[str]
     url: pydantic.AnyHttpUrl
-    input: list
-    output: list
+    input: List[Input]
+    output: List[Output]
 
     class Config:
         title = "CLAMS AppMetadata"

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -8,14 +8,6 @@ import clams
 primitives = Union[int, str, bool]
 
 
-class InputSpec(pydantic.BaseModel):
-    input: list = []
-
-
-class OutputSpec(pydantic.BaseModel):
-    output: list = []
-
-
 class AppMetadata(pydantic.BaseModel):
     name: str
     description: str
@@ -25,8 +17,8 @@ class AppMetadata(pydantic.BaseModel):
     license: str
     wrapper_license: Optional[str]
     url: pydantic.AnyHttpUrl
-    input_spec: "InputSpec"
-    output_spec: "OutputSpec"
+    input: list
+    output: list
 
     class Config:
         title = "CLAMS AppMetadata"
@@ -34,8 +26,8 @@ class AppMetadata(pydantic.BaseModel):
         extra = 'forbid'
         allow_population_by_field_name = True
         schema_extra = {
-            '$schema' : "http://json-schema.org/draft-07/schema#", # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
-            '$comment' : f"clams-python SDK {clams.__version__} was used to generate this schema" # this is only to hold version information
+            '$schema': "http://json-schema.org/draft-07/schema#", # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
+            '$comment': f"clams-python SDK {clams.__version__} was used to generate this schema" # this is only to hold version information
         }
 
 if __name__ == '__main__':

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -121,17 +121,23 @@ class AppMetadata(pydantic.BaseModel):
             schema['$schema'] = "http://json-schema.org/draft-07/schema#"  # currently pydantic doesn't natively support the $schema field. See https://github.com/samuelcolvin/pydantic/issues/1478
             schema['$comment'] = f"clams-python SDK {clams.__version__} was used to generate this schema"  # this is only to hold version information
         
-    def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = False, **properties):
-        if at_type not in [input.at_type for input in self.input]:
-            self.input.append(Input(at_type=str(at_type), required=required, properties=dict(properties)))
-            if required:
+    def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = True, **properties):
+        new_inp = Input(at_type=at_type, required=required)
+        if len(properties) > 0:
+            new_inp.properties = properties
+        if new_inp not in self.input:
+            self.input.append(new_inp)
+            if not required:
                 # TODO (krim @ 5/12/21): automatically add *optional* input types to parameter
                 # see https://github.com/clamsproject/clams-python/issues/29 for discussion
                 pass
         
     def add_output(self, at_type: Union[str, vocabulary.ThingTypesBase], **properties):
         if at_type not in [output.at_type for output in self.output]:
-            self.output.append(Output(at_type=str(at_type), properties=dict(properties)))
+            if len(properties) > 0:
+                self.output.append(Output(at_type=str(at_type), properties=dict(properties)))
+            else:
+                self.output.append(Output(at_type=str(at_type)))
     
     def add_parameter(self, name: str, description: str, value_spec: Union[dict, RuntimeParameterValue]):
         if type(value_spec) == dict:

--- a/clams/source/__init__.py
+++ b/clams/source/__init__.py
@@ -233,7 +233,7 @@ def generate_source_mmif(documents, prefix=None):
         elif prefix and not path.isabs(location):
             location = path.join(prefix, location)
         doc = template.substitute(
-            at_type=at_types[mime.split('/', maxsplit=1)[0]].value,
+            at_type=str(at_types[mime.split('/', maxsplit=1)[0]]),
             aid=f'd{doc_id}',
             mime=mime,
             location=location

--- a/documentation/appdirectory.rst
+++ b/documentation/appdirectory.rst
@@ -1,6 +1,6 @@
 .. _appdirectory:
 
-CLAMS app directory
+CLAMS App Directory
 ===================
 
 CLAMS app directory is under development, aiming at a public registry for free and open CLAMS apps.

--- a/documentation/autodoc/clams.app.rst
+++ b/documentation/autodoc/clams.app.rst
@@ -6,6 +6,6 @@ Module contents
 
 .. automodule:: clams.app
    :members:
-   :private-members: _annotate, _appmetadata, _input_spec, _output_spec
+   :private-members: _annotate, _appmetadata
    :undoc-members:
    :show-inheritance:

--- a/documentation/autodoc/clams.app.rst
+++ b/documentation/autodoc/clams.app.rst
@@ -6,6 +6,6 @@ Module contents
 
 .. automodule:: clams.app
    :members:
-   :private-members: _annotate, _appmetadata
+   :private-members: _annotate, _appmetadata, _input_spec, _output_spec
    :undoc-members:
    :show-inheritance:

--- a/documentation/autodoc/clams.appmetadata.rst
+++ b/documentation/autodoc/clams.appmetadata.rst
@@ -1,0 +1,10 @@
+clams.appmetadata package
+====================
+
+Module contents
+---------------
+
+.. automodule:: clams.appmetadata
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/documentation/autodoc/clams.appmetadata.rst
+++ b/documentation/autodoc/clams.appmetadata.rst
@@ -1,10 +1,8 @@
 clams.appmetadata package
-====================
+=========================
 
 Module contents
 ---------------
 
-.. automodule:: clams.appmetadata
+.. autoclass:: clams.appmetadata.AppMetadata
    :members:
-   :undoc-members:
-   :show-inheritance:

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 import datetime
+import mmif
 sys.path.insert(0, os.path.abspath(os.path.join('.', 'documentation')))
 
 
@@ -33,14 +34,16 @@ extensions = [
         'sphinx.ext.linkcode',
         'sphinx.ext.intersphinx',
         'sphinx_rtd_theme',
-        'm2r2']
+        'sphinx-jsonschema',
+        'm2r2'
+]
 #  autodoc_typehints = 'description'
 source_suffix = [".rst", ".md"]
 
 # mapping for external documentations
 intersphinx_mapping = {
         'python': ('https://docs.python.org/3', None),
-        'mmif': ('https://clamsproject.github.io/mmif-python', None)
+        'mmif': (f'https://clamsproject.github.io/mmif-python/{mmif.__version__}', None)
         }
 
 

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -8,6 +8,7 @@ Welcome to CLAMS Python SDK documentation!
   :caption: Contents
 
   introduction
+  appmetadata
   appdirectory
   tutorial
 

--- a/documentation/introduction.rst
+++ b/documentation/introduction.rst
@@ -10,6 +10,13 @@ The CLAMS project has many moving parts to make various computational analysis t
 
 A CLAMS app can be any software that performs automated contents analysis on text, audio, and/or image/video data stream. An app must use `MMIF <https://mmif.clams.ai>`_ as I/O format. When deployed into a CLAMS appliance, an app needs be running as a webapp wrapped in a docker container. In this documentation, we will explain what Python API's and HTTP API's an app must implement. 
 
+Quick Links
+-----------
+
+* `CLAMS App Metadata jsonschema <appmetadata.jsonschema>`_. 
+* `MMIF specification documentation <https://mmif.clams.ai/>`_. 
+* `mmif-python API documentation <https://clams.ai/mmif-python/>`_. 
+
 Prerequisites
 -------------
 
@@ -59,19 +66,22 @@ For more information on the relation between ``mmif-python`` versions and MMIF s
 
 CLAMS App API
 -------------
-A CLAMS Python app is a python class that implements and exposes two core methods; ``annotate()``, ``appmetadata()``. And a good place to start writing a CLAMS app is to start with inheriting :class:`clams.app.ClamsApp`.
-
-If you're using :class:`clams.app.ClamsApp` as a super class of your app, you need to implement two methods :meth:`~clams.app.ClamsApp._appmetadata` and :meth:`~clams.app.ClamsApp._annotate`. Because following public methods in the class internally call those private methods respectively. 
+A CLAMS Python app is a python class that implements and exposes two core methods; ``annotate()``, ``appmetadata()``. 
 
 * :meth:`~clams.app.ClamsApp.appmetadata`: Returns JSON-formatted :class:`str` that contains metadata about the app. 
 * :meth:`~clams.app.ClamsApp.annotate`: Takes a MMIF as the only input and processes the MMIF input, then returns serialized MMIF :class:`str`.
+
+A good place to start writing a CLAMS app is to start with inheriting :class:`clams.app.ClamsApp`. And if you're doing so, you might want to implement two private methods instead of two public methods above. That's because the implementation of the public methods in the super class internally call these private methods respectively. 
+
+* :meth:`~clams.app.ClamsApp._appmetadata` (using a :py:class:`~mmif.serialize.mmif.Mmif` object) and 
+* :meth:`~clams.app.ClamsApp._annotate` (using a :class:`~clams.appmetadata.AppMetadata` object)  
 
 We provide a tutorial for writing with a real world example at <:ref:`tutorial`>. We highly recommend you to go through it. 
 
 Note on App metadata
 ^^^^^^^^^^^^^^^^^^^^^
 App metadata is a map where important information about the app itself is stored as key-value pairs. 
-The specification is provided as a JSON schema at `here <appmetadata.jsonschema>`_. 
+See <:ref:`appmetadata`> for the specification. 
 In the future the app metadata will be used for automatic generation of CLAMS App index in the :ref:`appdirectory`, as well as automatic integration to Galaxy in the appliance deployment. 
 
 HTTP webapp

--- a/documentation/introduction.rst
+++ b/documentation/introduction.rst
@@ -69,7 +69,9 @@ We provide a tutorial for writing with a real world example at <:ref:`tutorial`>
 
 Note on App metadata
 ^^^^^^^^^^^^^^^^^^^^^
-App metadata is a map where important information about the app itself is stored as key-value pairs. At the moment, there's no standard metadata scheme. In the future the app metadata will be used for automatic generation of CLAMS App index in the :ref:`appdirectory`, as well as automatic integration to Galaxy in the appliance deployment. 
+App metadata is a map where important information about the app itself is stored as key-value pairs. 
+The specification is provided as a JSON schema at `here <appmetadata.jsonschema>`_. 
+In the future the app metadata will be used for automatic generation of CLAMS App index in the :ref:`appdirectory`, as well as automatic integration to Galaxy in the appliance deployment. 
 
 HTTP webapp
 -----------

--- a/documentation/modules.rst
+++ b/documentation/modules.rst
@@ -8,3 +8,4 @@ API documentation
    autodoc/clams.restify
    autodoc/clams.app
    autodoc/clams.source
+   autodoc/clams.appmetadata

--- a/documentation/tutorial.rst
+++ b/documentation/tutorial.rst
@@ -222,29 +222,34 @@ Steps 1 and 2 are still a bit unconstrained at this point.
 1.1 ``_appmetadata``
 ^^^^^^^^^^^^^^^^^^^^^
 
-This method should just return a dictionary containing the metadata
-relevant to your app. Metadata format will be standardized at a later
-date but for now is rather informal
+This method should just return a :class:`clams.appmetadata.AppMetadata` .
+containing the metadata relevant to your app. 
 
 .. code:: python
 
    class Kaldi(ClamsApp):
 
-       def _appmetadata(self) -> dict:
-           return {
-               "name": "Kaldi Wrapper",
-               "description": "This tool wraps the Kaldi ASR tool",
-               "vendor": "Team CLAMS",
-               "iri": f"http://mmif.clams.ai/apps/kaldi/{APP_VERSION}",
-               "wrappee": WRAPPED_IMAGE,
-               "requires": [DocumentTypes.AudioDocument.value],
-               "produces": [
-                   DocumentTypes.TextDocument.value,
-                   AnnotationTypes.TimeFrame.value,
-                   AnnotationTypes.Alignment.value,
-                   Uri.TOKEN
-               ]
-           }
+       def _appmetadata(self) -> AppMetadata:
+           app_version = '0.0.1'
+           kaldi_version = 'v1'
+           metadata = AppMetadata(
+              name="Kaldi Wrapper",
+              description="This tool wraps the Kaldi ASR tool",
+              app_version=app_version,
+              wrapper_version=kaldi_version
+              license="MIT",
+              identifier=f"https://apps.clams.ai/apps/kaldi/{exampleappversion}",
+           )
+           metadata.add_input(DocumentTypes.AudioDocument)
+           metadata.add_output(DocumentTypes.TextDocument)
+           metadata.add_output(AnnotationTypes.TimeFrame)
+           metadata.add_output(AnnotationTypes.Alignment)
+           metadata.add_output(Uri.TOKEN)
+           return metadata
+
+One can initiate a :class:`~clams.appmetadata.AppMetadata` object simply passing key-value pairs. 
+Also the class provides helper methods for structured fields (``input``, ``output``, and ``parameters``), so it is highly recommended to read the class documentation before you start specifying an app metadata.
+To see what fields need to be specified in the app metadata, see <:ref:`appmetadata`>. 
 
 .. _header-n47:
 

--- a/requirements.dev
+++ b/requirements.dev
@@ -5,6 +5,7 @@ twine
 # 3.3.0 has a bug that makes m2r2 not running
 sphinx<3.3.0
 sphinx-rtd-theme
+sphinx-jsonschema
 autodoc
 m2r2
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==1.1.0
 Flask-RESTful==0.3.8
 mmif-python==0.3.1
 lapps==0.0.2
+pydantic==1.7.3
+jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==1.1.0
 Flask-RESTful==0.3.8
+gunicorn==20.1.0
 mmif-python==0.3.3
 lapps==0.0.2
 pydantic==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-
+import distutils.cmd
 import os
 from os import path
 import shutil
@@ -11,12 +11,12 @@ cmdclass = {}
 
 try:
     from sphinx.setup_command import BuildDoc
+
     cmdclass['build_sphinx'] = BuildDoc
 except ImportError:
     print('WARNING: sphinx not available, not building docs')
 
-
-with open("VERSION", 'r') as version_f: 
+with open("VERSION", 'r') as version_f:
     version = version_f.read().strip()
 
 with open('README.md') as readme:
@@ -32,22 +32,39 @@ init_mod = open(path.join(ver_pack_dir, '__init__.py'), 'w')
 init_mod.write(f'__version__ = "{version}"')
 init_mod.close()
 
+
+class DoNothing(distutils.cmd.Command):
+    description = "run base code until `setuptools.setup(` line and exits 0."
+    user_options = []
+
+    def initialize_options(self) -> None:
+        pass
+
+    def finalize_options(self) -> None:
+        pass
+
+    def run(self):
+        pass
+
+
+cmdclass['donothing'] = DoNothing
+
 setuptools.setup(
-    name="clams-python", 
+    name="clams-python",
     version=version,
-    author="Brandeis Lab for Linguistics and Computation", 
+    author="Brandeis Lab for Linguistics and Computation",
     author_email="admin@clams.ai",
-    description="A collection of APIs to develop CLAMS app for python", 
+    description="A collection of APIs to develop CLAMS app for python",
     long_description=long_desc,
     long_description_content_type="text/markdown",
     url="https://www.clams.ai",
     classifiers=[
-    'Development Status :: 2 - Pre-Alpha',
-    'Framework :: Flask',
-    'Framework :: Pytest',
-    'Intended Audience :: Developers ',
-    'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3 :: Only',
+        'Development Status :: 2 - Pre-Alpha',
+        'Framework :: Flask',
+        'Framework :: Pytest',
+        'Intended Audience :: Developers ',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3 :: Only',
     ],
     cmdclass=cmdclass,
     command_options={
@@ -58,8 +75,8 @@ setuptools.setup(
             #  'release': ('setup.py', release),
             'build_dir': ('setup.py', 'documentation/_build'),
             'builder': ('setup.py', 'html'),
-            }
-        },
+        }
+    },
     install_requires=requires,
     python_requires='>=3.6',
     packages=setuptools.find_packages(),

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -105,7 +105,7 @@ class TestClamsApp(unittest.TestCase):
         self.assertTrue('properties' not in metadata['output'][0])
         self.assertTrue('properties' not in metadata['input'][0])
         self.assertTrue(metadata['input'][0]['required'])
-        self.assertEqual(len(metadata['parameters']), 0)
+        self.assertFalse('parameters' in metadata)
         
         # test add_X methods
         self.app.metadata.add_output(AnnotationTypes.BoundingBox)

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -58,7 +58,16 @@ class TestSerialization(unittest.TestCase):
 class ExampleClamsApp(clams.app.ClamsApp):
 
     def _appmetadata(self) -> Union[dict, AppMetadata]:
-        pass
+        exampleappversion = '0.0.1'
+        return AppMetadata(
+            name="Example CLAMS App for testing",
+            description="This app doesn't do anything",
+            app_version=exampleappversion,
+            license="MIT",
+            identifier=f"https://apps.clams.ai/example/{exampleappversion}",
+            input=[],
+            output=[]
+        )
     
     def _input_spec(self):
         return []
@@ -82,16 +91,6 @@ class ExampleClamsApp(clams.app.ClamsApp):
 class TestClamsApp(unittest.TestCase):
     
     def setUp(self):
-        self.exampleappversion = '0.0.1'
-        self.exampleappmetadata = AppMetadata(
-            name="Example CLAMS App for testing",
-            description="This app doesn't do anything",
-            app_version=self.exampleappversion,
-            license="MIT",
-            url=f"https://apps.clams.ai/example/{self.exampleappversion}",
-            input=[],
-            output=[]
-        )
         self.appmetadataschema = json.loads(AppMetadata.schema_json())
         self.app = ExampleClamsApp()
         self.in_mmif = ExampleInputMMIF.get_mmif()
@@ -101,8 +100,6 @@ class TestClamsApp(unittest.TestCase):
         self.assertIsNotNone(self.appmetadataschema)
 
     def test_appmetadata(self):
-        # from AppMetadata class
-        self.app.metadata = self.exampleappmetadata
         metadata = json.loads(self.app.appmetadata(pretty=True))
         jsonschema.validate(metadata, self.appmetadataschema)
         print(self.app.appmetadata(pretty=True))

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -66,16 +66,10 @@ class ExampleClamsApp(clams.app.ClamsApp):
             license="MIT",
             identifier=f"https://apps.clams.ai/example/{exampleappversion}",
             input=[],
-            output=[],
+            output=[Output(at_type=AT_TYPE.value)],
             parameters=[]
         )
     
-    def _input_spec(self):
-        return []
-        
-    def _output_spec(self):
-        return [Output(at_type=AT_TYPE.value)]
-
     def _annotate(self, mmif, raise_error=False):
         if type(mmif) is not Mmif:
             mmif = Mmif(mmif, validate=False)

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -65,9 +65,9 @@ class ExampleClamsApp(clams.app.ClamsApp):
             app_version=exampleappversion,
             license="MIT",
             identifier=f"https://apps.clams.ai/example/{exampleappversion}",
-            input=[{'at_type': DocumentTypes.AudioDocument}],
-            output=[{'at_type': AnnotationTypes.TimeFrame}],
+            output=[{'@type': AnnotationTypes.TimeFrame}],
         )
+        metadata.add_input(DocumentTypes.AudioDocument)
         return metadata
     
     def _annotate(self, mmif, raise_error=False):

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -66,7 +66,8 @@ class ExampleClamsApp(clams.app.ClamsApp):
             license="MIT",
             identifier=f"https://apps.clams.ai/example/{exampleappversion}",
             input=[],
-            output=[]
+            output=[],
+            parameters=[]
         )
     
     def _input_spec(self):

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -64,8 +64,8 @@ class ExampleClamsApp(clams.app.ClamsApp):
             app_version=version,
             license="MIT",
             url=f"https://apps.clams.ai/example/{version}",
-            input_spec=[],
-            output_spec=[]
+            input=[],
+            output=[]
         ).dict(exclude_none=True)
 
     def _annotate(self, mmif):

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -102,6 +102,7 @@ class TestClamsApp(unittest.TestCase):
         self.app.metadata = self.exampleappmetadata
         metadata = json.loads(self.app.appmetadata(pretty=True))
         jsonschema.validate(metadata, self.appmetadataschema)
+        print(self.app.appmetadata(pretty=True))
         
     def test_annotate(self):
         out_mmif = self.app.annotate(self.in_mmif)

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -9,8 +9,7 @@ from mmif import Mmif, Document, DocumentTypes, AnnotationTypes
 
 import clams.app
 import clams.restify
-import clams.appmetadata
-from clams.appmetadata import AppMetadata
+from clams.appmetadata import AppMetadata, Input, Output
 
 AT_TYPE = AnnotationTypes.TimeFrame
 
@@ -60,6 +59,12 @@ class ExampleClamsApp(clams.app.ClamsApp):
 
     def _appmetadata(self) -> Union[dict, AppMetadata]:
         pass
+    
+    def _input_spec(self):
+        return []
+        
+    def _output_spec(self):
+        return [Output(at_type=AT_TYPE.value)]
 
     def _annotate(self, mmif):
         if type(mmif) is not Mmif:
@@ -75,7 +80,7 @@ class TestClamsApp(unittest.TestCase):
     
     def setUp(self):
         self.exampleappversion = '0.0.1'
-        self.exampleappmetadata = clams.appmetadata.AppMetadata(
+        self.exampleappmetadata = AppMetadata(
             name="Example CLAMS App for testing",
             description="This app doesn't do anything",
             app_version=self.exampleappversion,
@@ -84,7 +89,7 @@ class TestClamsApp(unittest.TestCase):
             input=[],
             output=[]
         )
-        self.appmetadataschema = json.loads(clams.appmetadata.AppMetadata.schema_json())
+        self.appmetadataschema = json.loads(AppMetadata.schema_json())
         self.app = ExampleClamsApp()
         self.in_mmif = ExampleInputMMIF.get_mmif()
 
@@ -98,11 +103,6 @@ class TestClamsApp(unittest.TestCase):
         metadata = json.loads(self.app.appmetadata(pretty=True))
         jsonschema.validate(metadata, self.appmetadataschema)
         
-        # from plain dict
-        self.app.metadata = self.exampleappmetadata.dict(exclude_unset=True)
-        metadata = json.loads(self.app.appmetadata(pretty=True))
-        jsonschema.validate(metadata, self.appmetadataschema)
-
     def test_annotate(self):
         out_mmif = self.app.annotate(self.in_mmif)
         # TODO (krim @ 9/3/19): more robust test cases

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -9,7 +9,7 @@ from mmif import Mmif, Document, DocumentTypes, AnnotationTypes, View
 
 import clams.app
 import clams.restify
-from clams.appmetadata import AppMetadata, Input, Output, RuntimeParameter, RuntimeParameterValue
+from clams.appmetadata import AppMetadata
 
 
 
@@ -20,7 +20,7 @@ class ExampleInputMMIF(object):
     def get_rawmmif() -> Mmif:
         mmif = Mmif(validate=False, frozen=False)
 
-        vdoc = Document({'@type': DocumentTypes.VideoDocument.value,
+        vdoc = Document({'@type': DocumentTypes.VideoDocument,
                          'properties':
                              {'id': 'v1', 'location': "/dummy/dir/dummy.file.mp4"}})
         mmif.add_document(vdoc)
@@ -65,8 +65,8 @@ class ExampleClamsApp(clams.app.ClamsApp):
             app_version=exampleappversion,
             license="MIT",
             identifier=f"https://apps.clams.ai/example/{exampleappversion}",
-            input=[Input(at_type=DocumentTypes.AudioDocument.value)],
-            output=[Output(at_type=AnnotationTypes.TimeFrame)],
+            input=[{'at_type': DocumentTypes.AudioDocument}],
+            output=[{'at_type': AnnotationTypes.TimeFrame}],
         )
         return metadata
     
@@ -112,7 +112,7 @@ class TestClamsApp(unittest.TestCase):
         metadata = json.loads(self.app.appmetadata())
         self.assertEqual(len(metadata['output']), 2)
         # this should not be added as a duplicate
-        self.app.metadata.add_input(at_type=DocumentTypes.AudioDocument.value)
+        self.app.metadata.add_input(at_type=DocumentTypes.AudioDocument)
         metadata = json.loads(self.app.appmetadata())
         self.assertEqual(len(metadata['input']), 1)
         self.assertTrue('properties' not in metadata['input'][0])
@@ -125,12 +125,12 @@ class TestClamsApp(unittest.TestCase):
         # now parameters
         # using a custom class
         self.app.metadata.add_parameter(
-            'raise_error', 'force raise a ValueError',
-            RuntimeParameterValue(datatype='boolean', default='false'))
+            name='raise_error', description='force raise a ValueError', 
+            type='boolean', default='false')
         # using python dict
         self.app.metadata.add_parameter(
-            'multiple_choice', 'meaningless multiple choice option',
-            {'datatype': 'integer', 'choices': [1, 2, 3, 4, 5], 'default': 3})
+            name='multiple_choice', description='meaningless multiple choice option',
+            type='integer', choices=[1, 2, 3, 4, 5], default=3)
         metadata = json.loads(self.app.appmetadata())
         self.assertEqual(len(metadata['parameters']), 2)
         


### PR DESCRIPTION
This PR addresses #49, #52, and clamsproject/clams-apps#18 . Concretely, app metadata is defined as python objects (in `clams/appmetadata/__init__.py`) and *exported* as a JSON file while building documentation ([here](https://github.com/clamsproject/clams-python/compare/develop...49-metadata-schema?expand=1#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R46)). Generated JSON schema file has `$comment` field where developers can store the version of SDK used. At the moment, I don't see a point to keep a separate versioning for the schema, but if you use the same version string between the python SDK and app metadata schema, we need to carefully think through the compatibility issues when app metadata scheme is updated in the public branch. For now, input and output specifications are not handled. 

Here's the schema as defined now. 

``` json
{
  "title": "CLAMS AppMetadata",
  "description": "CLAMS AppMetadata defines metadata model that describes a CLAMS app",
  "type": "object",
  "properties": {
    "name": {
      "type": "string"
    },
    "description": {
      "type": "string"
    },
    "app_version": {
      "type": "string"
    },
    "mmif_version": {
      "default": "0.3.1",
      "type": "string"
    },
    "wrapper_version": {
      "type": "string"
    },
    "license": {
      "type": "string"
    },
    "wrapper_license": {
      "type": "string"
    },
    "url": {
      "minLength": 1,
      "maxLength": 65536,
      "format": "uri",
      "type": "string"
    },
    "input": {
      "type": "array",
      "items": {}
    },
    "output": {
      "type": "array",
      "items": {}
    }
  },
  "required": [
    "name",
    "description",
    "app_version",
    "license",
    "url",
    "input",
    "output"
  ],
  "additionalProperties": false,
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$comment": "clams-python SDK 0.2.3.dev1 was used to generate this schema"
}
```

And here's the metadata for [the example app used in the test suite](https://github.com/clamsproject/clams-python/compare/develop...49-metadata-schema?expand=1#diff-013ad51826f008ee90054b1c5c5f6e307f980374fb694814e8732e7ce5274fa5R77-R87). 

``` json
{
    "name": "Example CLAMS App for testing",
    "description": "This app doesn't do anything",
    "app_version": "0.0.1",
    "license": "MIT",
    "url": "https://apps.clams.ai/example/0.0.1",
    "input": [],
    "output": []
}
```
