### PR TITLE
Error responses now use code 500 

### DIFF
--- a/clams/restify/__init__.py
+++ b/clams/restify/__init__.py
@@ -95,12 +95,7 @@ class ClamsHTTPApi(Resource):
             return self.json_to_response(self.cla.annotate(in_mmif,
                                                            **params))
         except Exception as e:
-            code = 400
-            if type(e) == TypeError:
-                code = 415
-            elif type(e) == FileNotFoundError:
-                code = 404
-            return self.json_to_response(self.cla.record_error(in_mmif, params).serialize(), status=code)
+            return self.json_to_response(self.cla.record_error(in_mmif, params).serialize(), status=500)
 
     put = post
 

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -115,7 +115,7 @@ class TestClamsApp(unittest.TestCase):
         try: 
             out_mmif = self.app.annotate(in_mmif, **params)
         except Exception as e:
-            out_mmif = self.app.record_error(in_mmif, params)
+            out_mmif = self.app.set_error_view(in_mmif, params)
         self.assertIsNotNone(out_mmif)
         last_view: View = next(reversed(out_mmif.views))
         self.assertEqual(len(last_view.metadata.contains), 0)
@@ -170,13 +170,13 @@ class TestRestifier(unittest.TestCase):
         # this should raise TypeError because the ExampleClamsApp._annotate() doesn't take kwargs at all
         query_string = {'pretty': True, 'random': 'random'}
         res = self.app.put('/', data=mmif, headers=headers, query_string=query_string)
-        self.assertEqual(res.status_code, 415, res.get_data(as_text=True))
+        self.assertEqual(res.status_code, 500, res.get_data(as_text=True))
 
     def test_can_output_error(self):
         mmif = ExampleInputMMIF.get_mmif()
         query_string = {'pretty': True, 'raise_error': True}
         res = self.app.put('/', data=mmif, query_string=query_string)
-        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.status_code, 500)
         res_mmif = Mmif(res.get_data())
         self.assertEqual(len(res_mmif.views), 1)
         self.assertEqual(len(list(res_mmif.views)[0].annotations), 0)


### PR DESCRIPTION
resolves #61.
