### PR TITLE
releasing 0.4.3

### DIFF
--- a/clams/restify/__init__.py
+++ b/clams/restify/__init__.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import Dict
 
 from flask import Flask, request, Response
@@ -138,10 +137,9 @@ class ClamsHTTPApi(Resource):
         in_mmif = Mmif(request.get_data())
         params = self.annotate_param_caster.cast(request.args)
         try:
-            return self.json_to_response(self.cla.annotate(in_mmif,
-                                                           **params))
+            return self.json_to_response(self.cla.annotate(in_mmif, **params))
         except Exception as e:
-            return self.json_to_response(self.cla.record_error(in_mmif, params).serialize(), status=500)
+            return self.json_to_response(self.cla.record_error(in_mmif, params).serialize(pretty=True), status=500)
 
     put = post
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.0
 Flask-RESTful==0.3.8
 gunicorn==20.1.0
-mmif-python==0.4.2
+mmif-python==0.4.4
 lapps==0.0.2
 pydantic==1.8.2
 jsonschema==3.2.0


### PR DESCRIPTION
This release contains various fixes and improvements. 

* updated mmif-python to 0.4.4
* (added) C`lamsApp.get_configuration` will convert runtime parameters into actual runtime configuration that the app uses. This will help signing view.
* (fixed) Crash when `sign_view` with non-string parameter values
* (changed) MMIF with error is always prettified when returned as HTTP response
* (fixed) Adding duplicate input/output should not be allowed
* (changed) `AppMetadata.add_parameter` now has a proper signature for IDE hints
