### PR TITLE
pinned problematic dependency, updated flask 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-Flask==1.1.0
+Flask==1.1.4
 Flask-RESTful==0.3.8
+markupsafe==2.0.1
 gunicorn==20.1.0
 mmif-python==0.4.5
 lapps==0.0.2


### PR DESCRIPTION
This addresses #94 only by pinning to an older version of `markupsafe`. In the long term, we should consider updating flask to flask2. 