### PR TITLE
updating dependency versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OS: linux
-      PYTHON: '3.6'
+      PYTHON: '3.8'
     steps:
     - name: checkout the repo 
       uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Run test and generate coverage report
       working-directory: .
       run: |

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OS: linux
-      PYTHON: '3.6'
+      PYTHON: '3.8'
     needs: ['set-version', 'check-deployment']
     steps:
     - name: checkout the repo 
@@ -45,7 +45,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: set up docker buildx

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OS: linux
-      PYTHON: '3.6'
+      PYTHON: '3.8'
     steps:
     - name: checkout the repo 
       uses: actions/checkout@v2
     - name: setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: set VERSION value
       run: |
         echo "VERSION=$(echo "${{ github.ref }}" | cut -d/ -f3)" >> $GITHUB_ENV

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -41,6 +41,7 @@ def get_mmif_specver():
 class _BaseModel(pydantic.BaseModel):
     
     class Config:
+        @staticmethod
         def schema_extra(schema, model) -> None:
             for prop in schema.get('properties', {}).values():
                 prop.pop('title', None)

--- a/requirements.dev
+++ b/requirements.dev
@@ -2,8 +2,7 @@ pytype
 pytest
 pytest-cov
 twine
-# 3.3.0 has a bug that makes m2r2 not running
-sphinx<3.3.0
+sphinx
 sphinx-rtd-theme
 sphinx-jsonschema
 autodoc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==1.1.4
-Flask-RESTful==0.3.8
-markupsafe==2.0.1
-gunicorn==20.1.0
 mmif-python==0.4.6
-lapps==0.0.2
-pydantic==1.8.2
-jsonschema==3.2.0
+
+Flask>=2
+Flask-RESTful>=0.3.9
+gunicorn>=20
+lapps>=0.0.2
+pydantic>=1.8
+jsonschema>=3

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools.setup(
         }
     },
     install_requires=requires,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     packages=setuptools.find_packages(),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR includes updates on
1. minimum python requirements (also see https://github.com/clamsproject/mmif-python/issues/191) 
2. flask version (1 -> 2) (see #94)
3. "uncapping" other dependency versions. (see #89)

Using a new major version of flask needs more testing, which I'm working on. 