### PR TITLE
auto generate `app_version` value

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,5 +13,6 @@ jobs:
   test-and-codecov:
     name: test and check coverage
     uses: clamsproject/.github/.github/workflows/sdk-codecov.yml@main
-    secrets: inherit
+    secrets:
+      CC_REPO_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN_CLAMS_PYTHON }}
 

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -49,10 +49,7 @@ class ClamsApp(ABC):
         :return: Serialized JSON string of the metadata
         """
         pretty = kwargs.pop('pretty') if 'pretty' in kwargs else False
-        if pretty:
-            return self.metadata.json(exclude_defaults=True, by_alias=True, indent=2)
-        else:
-            return self.metadata.json(exclude_defaults=True, by_alias=True)
+        return self.metadata.jsonify(pretty)
 
     @abstractmethod
     def _appmetadata(self) -> AppMetadata:

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -9,7 +9,8 @@ import mmif
 import pydantic
 from mmif import vocabulary
 
-unresolved_app_version_num = 'unresolved'
+unresolved_app_version_num = 'unresolvable'
+app_version_envvar_key = 'CLAMS_APP_VERSION'
 primitives = Union[int, float, bool, str]
 # these names are taken from the JSON schema data types
 param_value_types = Literal['integer', 'number', 'string', 'boolean']
@@ -33,14 +34,13 @@ def get_clams_pyver():
 
 
 def generate_app_version(cwd=None):
-    if 'CLAMS_APP_VERSION' in os.environ:
-        return os.environ['CLAMS_APP_VERSION']
+    proc = subprocess.run(f'git --git-dir {Path(sys.modules["__main__"].__file__).parent.resolve() if cwd is None else cwd}/.git describe --tags --always'.split(), capture_output=True)
+    if proc.returncode == 0:
+        return proc.stdout.decode('utf8').strip()
+    elif app_version_envvar_key in os.environ:
+        return os.environ[app_version_envvar_key]
     else:
-        proc = subprocess.run(f'git --git-dir {Path(sys.modules["__main__"].__file__).parent.resolve() if cwd is None else cwd}/.git describe --tags --always'.split(), capture_output=True)
-        if proc.returncode == 0:
-            return proc.stdout.decode('utf8').strip()
-        else:
-            return unresolved_app_version_num
+        return unresolved_app_version_num
 
 
 def get_mmif_specver():

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -162,7 +162,9 @@ class AppMetadata(pydantic.BaseModel):
 
     @pydantic.validator('identifier', pre=True)
     def append_version(cls, val):
-        return f'{app_directory_baseurl if "/" not in val else""}/{val}{"" if val.endswith("/") else "/"}{generate_app_version()}'
+        prefix = f'{app_directory_baseurl if "/" not in val else""}'
+        suffix = generate_app_version()
+        return '/'.join(map(lambda x: x.strip('/'), filter(None, (prefix, val, suffix))))
 
     def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = True, **properties):
         """

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -166,6 +166,14 @@ class AppMetadata(pydantic.BaseModel):
         suffix = generate_app_version()
         return '/'.join(map(lambda x: x.strip('/'), filter(None, (prefix, val, suffix))))
 
+    @pydantic.validator('mmif_version', pre=True)
+    def auto_mmif_version(cls, val):
+        return get_mmif_specver()
+    
+    @pydantic.validator('app_version', pre=True)
+    def auto_app_version(cls, val):
+        return generate_app_version()
+
     def add_input(self, at_type: Union[str, vocabulary.ThingTypesBase], required: bool = True, **properties):
         """
         Helper method to add an element to the ``input`` list. 

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -57,6 +57,7 @@ class TestSerialization(unittest.TestCase):
 
 
 class ExampleClamsApp(clams.app.ClamsApp):
+    app_version = 'no-manual-version',
 
     def _appmetadata(self) -> Union[dict, AppMetadata]:
         
@@ -64,6 +65,7 @@ class ExampleClamsApp(clams.app.ClamsApp):
             name="Example CLAMS App for testing",
             description="This app doesn't do anything",
             app_license="MIT",
+            app_version=self.app_version,
             identifier=f"https://apps.clams.ai/example",
             output=[{'@type': AnnotationTypes.TimeFrame}],
             dependencies=['clams-python==develop-ver', 'mmif-pyhon==0.0.999'],
@@ -113,6 +115,7 @@ class TestClamsApp(unittest.TestCase):
         
         # test base metadata
         metadata = json.loads(self.app.appmetadata())
+        self.assertNotEquals(self.app.app_version, metadata['app_version'])
         self.assertEqual(len(metadata['output']), 1)
         self.assertEqual(len(metadata['input']), 1)
         self.assertTrue('properties' not in metadata['output'][0])

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -99,7 +99,11 @@ class TestClamsApp(unittest.TestCase):
         self.assertIsNotNone(self.appmetadataschema)
     
     def test_generate_app_version(self):
+        os.environ.pop(clams.appmetadata.app_version_envvar_key, None)
         self.assertEqual(clams.appmetadata.generate_app_version('not-existing-app'), clams.appmetadata.unresolved_app_version_num)
+        os.environ.update({clams.appmetadata.app_version_envvar_key:'v10'})
+        self.assertEqual(clams.appmetadata.generate_app_version('not-existing-app'), 'v10')
+        os.environ.pop(clams.appmetadata.app_version_envvar_key, None)
         # krim: have to admit that the way version generation is using local working directory makes it hard to test
         # self.assertTrue(clams.__version__.startswith(clams.appmetadata.generate_app_version('../').split('-')[0]))
 

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -60,7 +60,6 @@ class ExampleClamsApp(clams.app.ClamsApp):
 
     def _appmetadata(self) -> Union[dict, AppMetadata]:
         
-        exampleappversion = '0.0.1'
         metadata = AppMetadata(
             name="Example CLAMS App for testing",
             description="This app doesn't do anything",

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -64,9 +64,8 @@ class ExampleClamsApp(clams.app.ClamsApp):
         metadata = AppMetadata(
             name="Example CLAMS App for testing",
             description="This app doesn't do anything",
-            app_version=exampleappversion,
             app_license="MIT",
-            identifier=f"https://apps.clams.ai/example/{exampleappversion}",
+            identifier=f"https://apps.clams.ai/example",
             output=[{'@type': AnnotationTypes.TimeFrame}],
             dependencies=['clams-python==develop-ver', 'mmif-pyhon==0.0.999'],
             url="https://fakegithub.com/some/repository"
@@ -99,6 +98,11 @@ class TestClamsApp(unittest.TestCase):
     def test_jsonschema_export(self):
         # TODO (krim @ 4/20/21): there may be a better test for this...
         self.assertIsNotNone(self.appmetadataschema)
+    
+    def test_generate_app_version(self):
+        self.assertEqual(clams.appmetadata.generate_app_version('not-existing-app'), clams.appmetadata.unresolved_app_version_num)
+        # krim: have to admit that the way version generation is using local working directory makes it hard to test
+        # self.assertTrue(clams.__version__.startswith(clams.appmetadata.generate_app_version('../').split('-')[0]))
 
     def test_appmetadata(self):
         # base metadata setting is done in the ExampleClamsApp class


### PR DESCRIPTION
This PR closes #114. 

A few notes; 
* `app_version` value is generated using `git describe` first, and then using `$CLAMS_APP_VERSION` environment variable, then falls back to `unresolvable`. `git describe` comes first to ensure the proper versions are inferred in case where multiple apps running all natively (not via containers). (d0006dc)
* ~~The generation is done via pydantic default_factory, which won't prevent users from manually setting a value. I made it clearer in the documentation that this field (along with some others) is automatically filled, but existing apps need to be updated to "unset" app_versions.~~ (no longer the case after f8c6965)
* The generated version number is then automatically appended to the `identifier`. It means all existing apps should also be updated if the `identifier` field includes the version number (like [this](https://github.com/clamsproject/app-brandeis-acs/blob/6dd05fb0fd187a6575e1964d15520697bbfb48ec/app.py#L30)). Also 3ee9829 allows using a "shortname" for identifier (see the comment below)
* In addition to these changes, [a GHA workflow](https://github.com/clamsproject/.github/blob/main/.github/workflows/app-container.yml) should be updated to set and pass `$CLAMS_APP_VERSION` at the container build time. 