### PR TITLE
fixed version generation was not working when `git` cmd not found

### DIFF
--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import shutil
 from pathlib import Path
 from typing import Union, Dict, List, Optional, Literal
 
@@ -34,8 +35,15 @@ def get_clams_pyver():
 
 
 def generate_app_version(cwd=None):
-    proc = subprocess.run(f'git --git-dir {Path(sys.modules["__main__"].__file__).parent.resolve() if cwd is None else cwd}/.git describe --tags --always'.split(), capture_output=True)
-    if proc.returncode == 0:
+    gitcmd = shutil.which('git') 
+    gitdir = (Path(sys.modules["__main__"].__file__).parent.resolve() if cwd is None else Path(cwd)) / '.git'
+    if gitcmd is not None and gitdir.exists():
+        proc = subprocess.run(
+            f'{gitcmd} --git-dir "{gitdir}" describe --tags --always',
+            capture_output=True,
+            shell=True,
+            check=True,
+        )
         return proc.stdout.decode('utf8').strip()
     elif app_version_envvar_key in os.environ:
         return os.environ[app_version_envvar_key]

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 import warnings
+from pathlib import Path
 from typing import Union
 
 import pytest
@@ -93,12 +94,17 @@ class TestClamsApp(unittest.TestCase):
     
     def test_generate_app_version(self):
         os.environ.pop(clams.appmetadata.app_version_envvar_key, None)
-        self.assertEqual(clams.appmetadata.generate_app_version('not-existing-app'), clams.appmetadata.unresolved_app_version_num)
+        # should fail to generate version number if the directory of the app doesn't exist
+        self.assertEqual(clams.appmetadata.generate_app_version(cwd='not-existing-app'), 
+                         clams.appmetadata.unresolved_app_version_num)
+
         os.environ.update({clams.appmetadata.app_version_envvar_key:'v10'})
-        self.assertEqual(clams.appmetadata.generate_app_version('not-existing-app'), 'v10')
+        # should use version value from envvar if the directory of the app doesn't exist
+        self.assertEqual(clams.appmetadata.generate_app_version(cwd='not-existing-app'), 'v10')
         os.environ.pop(clams.appmetadata.app_version_envvar_key, None)
-        # krim: have to admit that the way version generation is using local working directory makes it hard to test
-        # self.assertTrue(clams.__version__.startswith(clams.appmetadata.generate_app_version('../').split('-')[0]))
+        # the version in development should be greater than the version in the last release
+        self.assertTrue(clams.__version__ >=
+                        clams.appmetadata.generate_app_version(cwd=Path(__file__).parent/'..').split('-')[0])
 
     def test_appmetadata(self):
         # base metadata setting is done in the ExampleClamsApp class


### PR DESCRIPTION
closes #138. 