### PR TITLE
releasing 1.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.5
+mmif-python==1.0.6
 
 Flask>=2
 Flask-RESTful>=0.3.9


### PR DESCRIPTION
### Overview
This release includes a bugfix and update to the latest mmif-python 

### Changes
* now based on `mmif-python==1.0.7`
* fixed some runtime parameters' default values not correctly casted (#173 )
