### PR TITLE
releasing 1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docs: VERSION $(generatedcode)
 	rm -rf docs
 	mkdir -p docs
 	python3 clams/appmetadata/__init__.py > documentation/appmetadata.jsonschema
-	sphinx-build -b html documentation/ docs
+	sphinx-build -a -b html documentation/ docs
 	mv documentation/appmetadata.jsonschema docs/
 	touch docs/.nojekyll
 	echo 'sdk.clams.ai' > docs/CNAME

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 1. a flask-based wrapper to run a Python CLAMS app as an HTTP web app
 1. cookie-cutter shell command that sets up everything and starts a new CLAMS app project
 
-### Start now from [Getting Started](introduction.html)!
+### Start now from [Getting Started](https://clamsproject.github.io/clams-python/introduction.html)!
 
 ## For more ...
-For user manuals and Python API documentation, take a look at [Python modules](https://clams.ai/clams-python/modules.html).
-
-For MMIF-specific Python API documentation, take a look at the [mmif-python website](https://clams.ai/mmif-python).
+* [Version history and patch notes](https://github.com/clamsproject/clams-python/blob/main/CHANGELOG.md)
+* [CLAMS Python API documentation](https://clamsproject.github.io/clams-python/modules.html)
+* [MMIF-specific Python API documentation](https://clamsproject.github.io/mmif-python)
+* [Public CLAMS App Directory](https://clamsproject.github.io/apps)

--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -137,7 +137,6 @@ class ClamsApp(ABC):
         
         #. Create a new view (or views) by calling :meth:`~mmif.serialize.mmif.Mmif.new_view` on the input mmif object.
         #. Call :meth:`~clams.app.ClamsApp.sign_view` with the input runtime parameters for the record.
-        #. Call :meth:`~clams.app.ClamsApp.get_configuration` to get an "upgraded" runtime parameters with default values.
         #. Call :meth:`~mmif.serialize.view.View.new_contain` on the new view object with any annotation properties specified by the configuration.
         #. Process the data and create :class:`~mmif.serialize.annotation.Annotation` objects and add them to the new view. 
         #. While doing so, get help from :class:`~mmif.vocabulary.document_types.DocumentTypes`, :class:`~mmif.vocabulary.annotation_types.AnnotationTypes` classes to generate ``@type`` strings.
@@ -177,7 +176,7 @@ class ClamsApp(ABC):
     def get_configuration(self, **runtime_params):
         warnings.warn("ClamsApp.get_configuration() is deprecated. "
                       "If you are using this method in `_annotate()` method,"
-                      "it is no longer needed since `clams-python==1.0.10`.", 
+                      "it is no longer needed since `clams-python>1.0.9`.", 
                       DeprecationWarning, stacklevel=2)
         return self._refine_params(**runtime_params)
 

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -12,7 +12,7 @@ from mmif import vocabulary
 unresolved_app_version_num = 'unresolvable'
 app_version_envvar_key = 'CLAMS_APP_VERSION'
 # type aliases to use in app metadata and runtime parameter processing 
-primitives = Union[int, float, bool, str]
+real_valued_primitives = Union[int, float, bool, str]
 # these names are taken from the JSON schema data types
 param_value_types = Literal['integer', 'number', 'string', 'boolean']
 
@@ -69,7 +69,7 @@ class Output(_BaseModel):
         alias="@type", 
         description="The type of the object. Must be a IRI string."
     )
-    properties: Dict[str, str] = pydantic.Field(
+    properties: Dict[str, real_valued_primitives] = pydantic.Field(
         {}, 
         description="(optional) Specification for type properties, if any."
     )
@@ -126,11 +126,11 @@ class RuntimeParameter(_BaseModel):
         ...,
         description=f"Type of the parameter value the app expects. Must be one of {param_value_types_values}."
     ) 
-    choices: List[primitives] = pydantic.Field(
+    choices: List[real_valued_primitives] = pydantic.Field(
         None, 
         description="(optional) List of string values that can be accepted."
     )
-    default: primitives = pydantic.Field(
+    default: real_valued_primitives = pydantic.Field(
         None, 
         description="(optional) Default value for the parameter. Only valid for optional parameters. Namely, setting "
                     "a default value makes a parameter 'optional'."
@@ -344,9 +344,9 @@ class AppMetadata(pydantic.BaseModel):
             raise ValueError(f"Cannot add a duplicate output '{new}'.")
 
     def add_parameter(self, name: str, description: str, type: param_value_types,
-                      choices: Optional[List[primitives]] = None,
+                      choices: Optional[List[real_valued_primitives]] = None,
                       multivalued: bool = False,
-                      default: primitives = None):
+                      default: real_valued_primitives = None):
         """
         Helper method to add an element to the ``parameters`` list. 
         """

--- a/clams/restify/__init__.py
+++ b/clams/restify/__init__.py
@@ -6,7 +6,7 @@ from flask_restful import Resource, Api
 from mmif import Mmif
 
 from clams.app import ClamsApp
-from clams.appmetadata import primitives
+from clams.appmetadata import real_valued_primitives
 
 
 class Restifier(object):
@@ -160,10 +160,10 @@ class ParameterCaster(object):
 
     :param param_spec: A specification of a data types of parameters
     """
-    def __init__(self, param_spec: Dict[str, Tuple[primitives, bool]]):
+    def __init__(self, param_spec: Dict[str, Tuple[real_valued_primitives, bool]]):
         self.param_spec = param_spec
 
-    def cast(self, args: Dict[str, List[str]]) -> Dict[str, Union[primitives, List[primitives]]]:
+    def cast(self, args: Dict[str, List[str]]) -> Dict[str, Union[real_valued_primitives, List[real_valued_primitives]]]:
         """
         Given parameter specification, tries to cast values of args to specified Python data types.
         Note that this caster deals with query strings, thus all keys and values in the input args are plain strings. 

--- a/clams/restify/__init__.py
+++ b/clams/restify/__init__.py
@@ -194,7 +194,10 @@ class ParameterCaster(object):
                         else: 
                             casted[k] = v
             else:
-                casted[k] = vs  
+                if len(vs) > 1:
+                    casted[k] = vs
+                else:
+                    casted[k] = vs[0]
                     
         return casted
 

--- a/documentation/tutorial.md
+++ b/documentation/tutorial.md
@@ -113,13 +113,15 @@ def _appmetadata(self):
 > Also refer to [CLAMS App Metadata](https://sdk.clams.ai/appmetadata.html) for more details regarding what fields need to be specified.
 
 #### `_annotate()`
-The `_annotate()` method should accept a MMIF file as its parameter and always returns a `MMIF` object with an additional `view` containing annotation results. This is where the bulk of your logic will go. For a text processing app, it is mostly concerned with finding text documents, calling the code that runs over the text, creating new views and inserting the results.
+The `_annotate()` method should accept a MMIF file/string/object as its first parameter and always returns a `MMIF` object with an additional `view` containing annotation results. This is where the bulk of your logic will go. For a text processing app, it is mostly concerned with finding text documents, calling the code that runs over the text, creating new views and inserting the results. 
+
+In addition to the input MMIF, this method can accept any number of keyword arguments, which are the parameters set by the user/caller. Note that when this method is called inside the `annotate()` public method in the `ClamsApp` class (which is the usual case when running as a CLAMS app), the keyword arguments are automatically "refined" before being passed here. The refinement includes 
+
+1. inserting "default" values for parameters that are not set by the user
+2. checking that the values are of the correct type and value, based on the parameter specification in the app metadata
 
 ```python
 def _annotate(self, mmif, **kwargs):
-    # before everything, this will populate the argument dict with the default values
-    # and while doing so, it will also do some validation of the argument values
-    configs = self.get_configuration(kwargs)
     # then, access the parameters: here to just print
     # them and to willy-nilly throw an error if the caller wants that
     for arg, val in configs.items():
@@ -146,7 +148,7 @@ The method  `_run_nlp_tool()` is responsible for running the NLP tool and adding
 
 One thing about `_annotate()` as it is defined above is that it will most likely be the same for each NLP application, all the application specific details are in the code that creates new views and the code that adds annotations.
 
-Creating a new view:
+##### Creating a new view:
 
 ```python
 def _new_view(self, docid=None, runtime_config):
@@ -163,7 +165,7 @@ def _new_view(self, docid=None, runtime_config):
 
 This is the simplest NLP view possible since there is only one annotation type and it has no metadata properties beyond the `document` property. Other applications may have more annotation types, which results in repeated invocations of `new_contain()`, and may define other metadata properties for those types.
 
-Adding annotations:
+##### Adding annotations:
 
 ```python
 def _run_nlp_tool(self, doc, new_view, full_doc_id):

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -127,7 +127,7 @@ class TestClamsApp(unittest.TestCase):
         self.app.metadata.add_output(AnnotationTypes.BoundingBox, boxType='text')
         metadata = json.loads(self.app.appmetadata())
         self.assertEqual(len(metadata['output']), 2)
-        # these should not be added as a duplicate
+        # these should not be added because they are duplicates
         with self.assertRaises(ValueError):
             self.app.metadata.add_input(at_type=DocumentTypes.TextDocument)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### Overview
This release contains minor fixes in code and updates in documentations regarding changes in runtime parameter in the previous 1.1.0 release.

### Changes
* fixed broken links in the main repo README
* fixed outdated information regarding usage of `get_configuration` in various documentation
* fixed `properties` in I/O specification in AppMetadata are unfairly restricted to `str` values