### PR TITLE
releasing 1.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.11
+mmif-python==1.0.13
 
 Flask>=2
 Flask-RESTful>=0.3.9


### PR DESCRIPTION
### Overview
Minor release to update the `mmif-python` dependency to the latest.

### Changes
* now based on `mmif-python==1.0.13` including a hotfix for a wrong field name in MMIF serialization.
