### PR TITLE
releasing 1.2.0

### DIFF
--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -15,6 +15,11 @@ app_version_envvar_key = 'CLAMS_APP_VERSION'
 real_valued_primitives = Union[int, float, bool, str]
 # these names are taken from the JSON schema data types
 param_value_types = Literal['integer', 'number', 'string', 'boolean', 'map']
+# and the specific delimiter for the map type
+map_param_kv_delimiter = ':'
+
+# dict to map app parameter data types to Python data types
+python_type = {"boolean": bool, "number": float, "integer": int, "string": str, "map": dict}
 
 param_value_types_values = param_value_types.__args__  # pytype: disable=attribute-error
 app_directory_baseurl = "http://apps.clams.ai"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.11
+mmif-python==1.0.13
 
 Flask>=2
 Flask-RESTful>=0.3.9

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -14,7 +14,7 @@ from mmif import Mmif, Document, DocumentTypes, AnnotationTypes, View, __specver
 import clams.app
 import clams.restify
 from clams.app import ParameterCaster
-from clams.appmetadata import AppMetadata, Input, RuntimeParameter
+from clams.appmetadata import AppMetadata, Input
 
 
 class ExampleInputMMIF(object):
@@ -420,19 +420,16 @@ class TestRestifier(unittest.TestCase):
 class TestParameterCaster(unittest.TestCase):
     
     def setUp(self) -> None:
-        self.params = []
-        specs = {'str_param': ('string', False),
-                 'number_param': ('number', False),
-                 'int_param': ('integer', False),
-                 'bool_param': ('boolean', False), 
-                 'str_multi_param': ('string', True),
-                 'map_param': ('map', True),
-                 }
-        for name, (t, mv) in specs.items():
-            self.params.append(RuntimeParameter(**{'name': name, 'type': t, 'multivalued': mv, 'description': ""}))
+        self.param_spec = {'str_param': ('string', False),
+                           'number_param': ('number', False),
+                           'int_param': ('integer', False),
+                           'bool_param': ('boolean', False),
+                           'str_multi_param': ('string', True),
+                           'map_param': ('map', True),
+                           }
 
     def test_cast(self):
-        caster = ParameterCaster(self.params)
+        caster = ParameterCaster(self.param_spec)
         params = {
             'str_param': ["a_string"], 
             'number_param': ["1.11"], 
@@ -443,6 +440,7 @@ class TestParameterCaster(unittest.TestCase):
             'undefined_param_multi': ['undefined_value1', 'undefined_value2'],
             'map_param': ['key1:val1', 'key2:val2', 'key3:val3', 'key1:val4']
         }
+        # all "RAW" parameter values are assumed to be strings
         self.assertTrue(all(map(lambda x: isinstance(x, str), itertools.chain.from_iterable(params.values()))))
         casted = caster.cast(params)
         # must push out to the list


### PR DESCRIPTION
### Overview
This is a minor release that brings improved portability of `clams source` command but also breaks some backward compatibility. If your app is based on clams-python 1.0.x or 1.1.x, please read the changelog carefully. 

### Changes
- `clams source` command now work on Windows shell. The paths still, though, have to be POSIX path. We have no plan to support Windows path for `file://` URI in MMIF at the moment. 
- `ClamsApp.sign_view` method now expect the runtime parameters (dict of string to lists of values) as a second argument. Previously the second argument was optional, which is no more. CLAMS app developers who were calling this method in `_annotate()` method must directly pass down the runtime parameters from `_annotate()` argument.
