### PR TITLE
adding `cli.py` for command line app use

### DIFF
--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -20,6 +20,16 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S")
 
 
+falsy_values = [
+    'False', 
+    'false', 
+    'F',
+    'f',
+    '0',
+    0, 
+    False
+]
+
 class ClamsApp(ABC):
     """
     An abstract class to define API's for ClamsApps. A CLAMS app should inherit
@@ -370,7 +380,7 @@ class ParameterCaster(object):
         """
         Helper function to convert string values to bool type.
         """
-        return False if value in (False, 0, 'False', 'false', '0') else True
+        return False if value in falsy_values else True
 
     @staticmethod
     def float_param(value) -> float:

--- a/clams/appmetadata/__init__.py
+++ b/clams/appmetadata/__init__.py
@@ -162,7 +162,8 @@ class RuntimeParameter(_BaseModel):
     type: param_value_types = pydantic.Field(
         ...,
         description=f"Type of the parameter value the app expects. Must be one of {param_value_types_values}. When "
-                    "type is ``map``, ``multivalued=true`` is automatically forced. \n\n"
+                    "type is ``map``, ``multivalued=true`` is forced, and when ``boolean``, ``multivalued=false`` is "
+                    "forced. \n\n"
                     "Notes for developers: \n\n"
                     "When the type is ``map``, the parameter value (still a single string from the users' perspective) "
                     "must be formatted as a ``KEY:VALUE`` pair, namely a colon-separated string. To pass multiple "
@@ -186,7 +187,7 @@ class RuntimeParameter(_BaseModel):
         description="(optional) Default value for the parameter.\n\n"
                     "Notes for developers: \n\n"
                     "Setting a default value makes a parameter `optional`. \n\n"
-                    "When ``multivalued=True``, the default value should be a list of values. \n\n"
+                    "When ``multivalued=true``, the default value should be a list of values. \n\n"
                     "When ``type=map``, the default value should be a list of colon-separated strings. \n\n"
     )
     multivalued: bool = pydantic.Field(
@@ -420,8 +421,10 @@ class AppMetadata(pydantic.BaseModel):
         # see https://docs.pydantic.dev/1.10/usage/types/#unions
         # e.g. casting 0.1 using the `primitives` dict will result in  0 (int)
         # while casting "0.1" using the `primitives` dict will result in  0.1 (float)
-        if type == 'map' and multivalued is False:
+        if type == 'map':
             multivalued = True
+        if type == 'boolean':
+            multivalued = False
         if default is not None:
             if isinstance(default, list):
                 default = [str(d) for d in default]

--- a/clams/develop/__init__.py
+++ b/clams/develop/__init__.py
@@ -87,19 +87,28 @@ class CookieCutter(object):
             if basename not in essentials:
                 # if non-essential, just skip when updating
                 continue
-            elif not (dst_dir / dirname / basename).exists():
-                # this file is new in the cookicutter 
-                out_fpath = dst_dir / dirname / basename
+            in_f = open(template, 'r')
+            tmpl_to_compile = Template(in_f.read())
+            compiled = tmpl_to_compile.safe_substitute(templating_vars)
+            in_f.close()
+            ori_fpath = dst_dir / dirname / basename
+            if not ori_fpath.exists():
+                # this file is new in this version of cookiecutter 
+                with open(ori_fpath, 'w') as out_f:
+                    out_f.write(compiled)
             else:
-                # when the target file already exists, we need to do diff & patch 
-                out_fpath = f'{(dst_dir / dirname / basename)}{update_tmp_suffix}'
-                # TODO (krim @ 5/5/24): add update level 2 and 3 code here
-                print(f'    {dst_dir / dirname / basename} already exists, generating a tmp file: {out_fpath}')
-            with open(template, 'r') as in_f, open(out_fpath, 'w') as out_f:
-                tmpl_to_compile = Template(in_f.read())
-                compiled = tmpl_to_compile.safe_substitute(templating_vars)
-                out_f.write(compiled)
-            
+                ori_f = open(ori_fpath, 'r')
+                ori_content = ori_f.read()
+                if ori_content != compiled:
+                    # when the target file already exists, we need to do diff & patch 
+                    # TODO (krim @ 5/5/24): add update level 2 and 3 code here
+                    out_fpath = f'{ori_fpath}{update_tmp_suffix}'
+                    print(f'    {dst_dir / dirname / basename} already exists, generating a tmp file: {out_fpath}')
+                    with open(out_fpath, 'w') as out_f:
+                        out_f.write(compiled)
+                else:
+                    print(f'    {dst_dir / dirname / basename} already exists, but the content is unchanged from the '
+                          f'template, skipping re-generating')
         print(f"App skeleton code is updated in {self.rawname}")
         print(f"  Checkout {self.rawname}/README.md for the next steps!")
 

--- a/clams/develop/__init__.py
+++ b/clams/develop/__init__.py
@@ -7,6 +7,7 @@ from typing import List
 
 import clams
 
+update_tmp_suffix = '.tmp'
 available_recipes = {
     'app': {
         'description': 'Skeleton code for a CLAMS app',
@@ -26,7 +27,7 @@ class CookieCutter(object):
     def __init__(self, name: str, outdir: str, recipes: List[str]):
         self.rawname = name 
         self.name_tokens = self.tokenize_rawname()
-        self.ourdir = pathlib.Path(outdir)
+        self.outdir = pathlib.Path(outdir)
         if recipes:
             self.recipes = recipes
         else:
@@ -42,24 +43,31 @@ class CookieCutter(object):
                 words.pop()
         return words
     
-    def bake(self):
+    def bake(self, update_level=0):
         print(f"Baking {self.recipes}")
         for recipe in self.recipes:
             src_dir = pathlib.Path(__file__).parent / 'templates' / available_recipes[recipe]['sourcedir']
-            dst_dir = self.ourdir / self.rawname / available_recipes[recipe]['targetdir']
+            dst_dir = self.outdir / self.rawname / available_recipes[recipe]['targetdir']
             if recipe == 'app':
-                self.bake_app(src_dir, dst_dir)
+                caps = [t.capitalize() for t in self.name_tokens]
+                app_vars = {
+                    'CLAMS_VERSION': clams.__version__,
+                    'APP_CLASS_NAME': "".join(caps),
+                    'APP_NAME': " ".join(caps),
+                    'APP_IDENTIFIER': '-'.join(self.name_tokens)
+                }
+                if update_level > 0:
+                    # self.reheat_app(src_dir, dst_dir, app_vars)
+                    pass
+                else:
+                    if dst_dir.exists():
+                        raise FileExistsError(f"  {dst_dir} already exists. Did you mean `--update`? ")
+                    self.bake_app(src_dir, dst_dir, app_vars)
             if recipe == 'gha':
+                # There's nothing for devs to tweak GHA template, so first generation and updating are the same.
                 self.bake_gha(src_dir, dst_dir)
             
-    def bake_app(self, src_dir, dst_dir):
-        caps = [t.capitalize() for t in self.name_tokens]
-        templating_vars = {
-            'CLAMS_VERSION': clams.__version__,
-            'APP_CLASS_NAME': "".join(caps),
-            'APP_NAME': " ".join(caps),
-            'APP_IDENTIFIER': '-'.join(self.name_tokens)
-        }
+    def bake_app(self, src_dir, dst_dir, templating_vars):
         for g in src_dir.glob("**/*.template"):
             r = g.relative_to(src_dir).parent
             f = g.with_suffix('').name
@@ -128,12 +136,22 @@ def prep_argparser(**kwargs):
         nargs='?',
         help='The name of the parent directory where the app skeleton directory is placed. (default: current directory)'
     )
+    parser.add_argument(
+        '-u', '--update',
+        action='count',
+        help=f'Set update level by passing this flag multiple times. This is EXPERIMENTAL, and developers MUST NOT'
+             f'rely on the update results, and should conduct manual checks afterward. LEVEL 0: does not update and '
+             f'raise an error when existing directory found. LEVEL 1: generate non-existing files and generate '
+             f'`{update_tmp_suffix}`-suffixed files for existing one. LEVEL 2 (WIP): generate non-existing files and '
+             f'automatically generate patch files for existing files. LEVEL 3 (WIP): generate non-existing files and '
+             f'apply patches to existing files. (default: 0)'
+    )
     return parser
 
 
 def main(args):
     cutter = CookieCutter(name=args.name, outdir=args.parent_dir, recipes=args.recipes)
-    cutter.bake()
+    cutter.bake(args.update)
 
 if __name__ == '__main__':
     parser = prep_argparser()

--- a/clams/develop/templates/app/app.py.template
+++ b/clams/develop/templates/app/app.py.template
@@ -39,6 +39,11 @@ class $APP_CLASS_NAME(ClamsApp):
         # see https://sdk.clams.ai/autodoc/clams.app.html#clams.app.ClamsApp._annotate
         raise NotImplementedError
 
+def get_app():
+    # singleton constructor for app
+    # return $APP_CLASS_NAME(init, from, global, params)
+    raise NotImplementedError
+    
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/clams/develop/templates/app/app.py.template
+++ b/clams/develop/templates/app/app.py.template
@@ -40,8 +40,13 @@ class $APP_CLASS_NAME(ClamsApp):
         raise NotImplementedError
 
 def get_app():
-    # singleton constructor for app
-    # return $APP_CLASS_NAME(init, from, global, params)
+    """
+    This function effectively creates an instance of the app class, without any arguments passed in, meaning, any 
+    external information such as initial app configuration should be set without using function arguments. The easiest
+    way to do this is to set global variables before calling this. 
+    """
+    # for example: 
+    # return $APP_CLASS_NAME(create, from, global, params)
     raise NotImplementedError
     
 
@@ -55,7 +60,9 @@ if __name__ == "__main__":
     parsed_args = parser.parse_args()
 
     # create the app instance
-    app = $APP_CLASS_NAME()
+    # if get_app() call requires any "configurations", they should be set now as global variables
+    # and referenced in the get_app() function. NOTE THAT you should not change the signature of get_app()
+    app = get_app()
 
     http_app = Restifier(app, port=int(parsed_args.port))
     # for running the application in production mode

--- a/clams/develop/templates/app/cli.py.template
+++ b/clams/develop/templates/app/cli.py.template
@@ -1,90 +1,69 @@
 #!/usr/bin/env python3
 """
-The purpose of this file is to define 
-a thin CLI interface for your app
+The purpose of this file is to define a thin CLI interface for your app
 
 DO NOT CHANGE the name of the file
 """
 
-
-# Imports
 import argparse
-import json
-import sys 
+import sys
 
-from typing import Dict, Union
-
-from app import ClamsApp, AppMetadata, get_app
+import app
 from mmif import Mmif
-# Dict to convert parameter types to python types
-type_map = {
-    "integer": int,
-    "number": float,
-    "string": str,
-    "boolean": bool,
-    "map": dict,
-}
-# ============================================================|
-def parse_metadata(app_metadata: AppMetadata) -> Dict[str, Union[str, float, int, bool, dict]]:
-    """Separate argparser for runtime parameters,
+from clams import AppMetadata
 
-    uses parameters accessible via `metadata.py` to
-    construct the argparse arguments, parses them,
-    and converts them to a dictionary of values before returning
+
+def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
+    """
+    Automatically generate an argparse.ArgumentParser from parameters specified in the app metadata (metadata.py).
     """
 
-    # helper function for argparse 'nargs' field
-    def _get_nargs(param):
-        if param.multivalued:
-            return "?" if param.type == "boolean" else "+"
-        return 1
-
-    parser = argparse.ArgumentParser(add_help=False,
-        description="Command-Line Interface for CLAMS app"
-    )
-
-    # keep track of dict-type values in parameters for later parsing
-    maps = set()
+    parser = argparse.ArgumentParser(description="CLI for CLAMS app")
 
     # parse cli args from app parameters
-    for parameter in app_metadata["parameters"]:
-        if type_map[parameter.type] == dict:
-            maps.add(parameter.name)
-        parser.add_argument(
+    for parameter in app_metadata.parameters:
+        a = parser.add_argument(
             f"--{parameter.name}",
             help=parameter.description,
-            nargs=_get_nargs(parameter),
-            type=type_map[parameter.type],
-            choices=parameter.choices,
-            default=parameter.default,
+            nargs=1,
             action="store",
-        )
+            type=str)
+        if parameter.choices is not None:
+            a.choices = parameter.choices
+        if parameter.default is not None:
+            a.help += f" (default: {parameter.default})"
+            # then we don't have to add default values to the arg_parser
+            # since that's handled by the app._refined_params() method.
+        if parameter.multivalued:
+            a.nargs = '+'
+        if parameter.type == "boolean":
+            a.nargs = '?'
+            a.action = "store_true"
+    parser.add_argument('IN_MMIF_FILE', nargs='?', type=argparse.FileType('r'),
+                        # will check if stdin is a keyboard, and return None if it is
+                        default=None if sys.stdin.isatty() else sys.stdin)
+    parser.add_argument('OUT_MMIF_FILE', nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+    return parser
 
-    # namespace -> dictionary
-    app_args = vars(parser.parse_args())
-
-    # convert dict-type arg strings into k/v pairs
-    for arg, val in app_args.items():
-        if arg in maps:
-            app_args[arg] = {k: v for k, v in [pair.split(":") for pair in val]}
-
-    return app_args
-
-
-def main():
-    # CLI pipeline: `stdin` -> app._annotate -> `stdout`
-    input = sys.stdin
-
-    # Load data from stdin 
-    in_data = Mmif("".join([line.rstrip("\n") for line in input]))
-
-    # Load app from `app.py` constructor and get runtime params
-    clamsapp: ClamsApp = get_app()
-    app_metadata = dict(json.loads(clamsapp.appmetadata()))
-    runtime_parameters = parse_metadata(app_metadata=app_metadata)
-
-    # Write _annotate output (mmif) to stdout
-    print(clamsapp._annotate(in_data, **runtime_parameters), file=sys.stdout)
 
 if __name__ == "__main__":
-    main()
+    clamsapp = app.get_app()
+    arg_parser = metadata_to_argparser(app_metadata=clamsapp.metadata)
+    args = arg_parser.parse_args()
+    if args.IN_MMIF_FILE:
+        in_data = Mmif(args.IN_MMIF_FILE.read())
+        # since flask webapp interface will pass parameters as "unflattened" dict to handle multivalued parameters
+        # (https://werkzeug.palletsprojects.com/en/latest/datastructures/#werkzeug.datastructures.MultiDict.to_dict)
+        # we need to convert arg_parsers results into a similar structure, which is the dict values are wrapped in lists
+        params = {}
+        for pname, pvalue in vars(args).items():
+            if pvalue is None or pname in ['IN_MMIF_FILE', 'OUT_MMIF_FILE']:
+                continue
+            elif isinstance(pvalue, list):
+                params[pname] = pvalue
+            else:
+                params[pname] = [pvalue]
+        args.OUT_MMIF_FILE.write(clamsapp.annotate(in_data, **params))
+    else:
+        arg_parser.print_help()
+        sys.exit(1)

--- a/clams/develop/templates/app/cli.py.template
+++ b/clams/develop/templates/app/cli.py.template
@@ -7,9 +7,9 @@ DO NOT CHANGE the name of the file
 
 import argparse
 import sys
+from contextlib import redirect_stdout
 
 import app
-from mmif import Mmif
 from clams import AppMetadata
 
 
@@ -40,9 +40,15 @@ def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
             a.nargs = '?'
             a.action = "store_true"
     parser.add_argument('IN_MMIF_FILE', nargs='?', type=argparse.FileType('r'),
+                        help='input file path, STDIN if `-` or not provided. NOTE: When running this cli.py in a '
+                             'containerized environment, make sure the container is run with `-i` flag to keep stdin '
+                             'open.',
                         # will check if stdin is a keyboard, and return None if it is
                         default=None if sys.stdin.isatty() else sys.stdin)
-    parser.add_argument('OUT_MMIF_FILE', nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('OUT_MMIF_FILE', nargs='?', type=argparse.FileType('w'), 
+                        help='output file path, STDOUT if `-` or not provided. NOTE: When this is set to STDOUT, any '
+                             'print statements in the app code will be redirected to stderr.',
+                        default=sys.stdout)
     return parser
 
 
@@ -51,7 +57,7 @@ if __name__ == "__main__":
     arg_parser = metadata_to_argparser(app_metadata=clamsapp.metadata)
     args = arg_parser.parse_args()
     if args.IN_MMIF_FILE:
-        in_data = Mmif(args.IN_MMIF_FILE.read())
+        in_data = args.IN_MMIF_FILE.read()
         # since flask webapp interface will pass parameters as "unflattened" dict to handle multivalued parameters
         # (https://werkzeug.palletsprojects.com/en/latest/datastructures/#werkzeug.datastructures.MultiDict.to_dict)
         # we need to convert arg_parsers results into a similar structure, which is the dict values are wrapped in lists
@@ -63,7 +69,12 @@ if __name__ == "__main__":
                 params[pname] = pvalue
             else:
                 params[pname] = [pvalue]
-        args.OUT_MMIF_FILE.write(clamsapp.annotate(in_data, **params))
+        if args.OUT_MMIF_FILE.name == '<stdout>':
+            with redirect_stdout(sys.stderr):
+                out_mmif = clamsapp.annotate(in_data, **params)
+        else:
+            out_mmif = clamsapp.annotate(in_data, **params)
+        args.OUT_MMIF_FILE.write(out_mmif)
     else:
         arg_parser.print_help()
         sys.exit(1)

--- a/clams/develop/templates/app/cli.py.template
+++ b/clams/develop/templates/app/cli.py.template
@@ -18,7 +18,9 @@ def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
     Automatically generate an argparse.ArgumentParser from parameters specified in the app metadata (metadata.py).
     """
 
-    parser = argparse.ArgumentParser(description="CLI for CLAMS app")
+    parser = argparse.ArgumentParser(
+        description=f"{app_metadata.name}: {app_metadata.description} (visit {app_metadata.url} for more info)",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
 
     # parse cli args from app parameters
     for parameter in app_metadata.parameters:
@@ -40,14 +42,14 @@ def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
             a.nargs = '?'
             a.action = "store_true"
     parser.add_argument('IN_MMIF_FILE', nargs='?', type=argparse.FileType('r'),
-                        help='input file path, STDIN if `-` or not provided. NOTE: When running this cli.py in a '
-                             'containerized environment, make sure the container is run with `-i` flag to keep stdin '
+                        help='input MMIF file path, or STDIN if `-` or not provided. NOTE: When running this cli.py in '
+                             'a containerized environment, make sure the container is run with `-i` flag to keep stdin '
                              'open.',
                         # will check if stdin is a keyboard, and return None if it is
                         default=None if sys.stdin.isatty() else sys.stdin)
     parser.add_argument('OUT_MMIF_FILE', nargs='?', type=argparse.FileType('w'), 
-                        help='output file path, STDOUT if `-` or not provided. NOTE: When this is set to STDOUT, any '
-                             'print statements in the app code will be redirected to stderr.',
+                        help='output MMIF file path, or STDOUT if `-` or not provided. NOTE: When this is set to '
+                             'STDOUT, any print statements in the app code will be redirected to stderr.',
                         default=sys.stdout)
     return parser
 

--- a/clams/develop/templates/app/cli.py.template
+++ b/clams/develop/templates/app/cli.py.template
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+The purpose of this file is to define 
+a thin CLI interface for your app
+
+DO NOT CHANGE the name of the file
+"""
+
+
+# Imports
+import argparse
+import json
+import sys 
+
+from typing import Dict, Union
+
+from app import ClamsApp, AppMetadata, get_app
+from mmif import Mmif
+# Dict to convert parameter types to python types
+type_map = {
+    "integer": int,
+    "number": float,
+    "string": str,
+    "boolean": bool,
+    "map": dict,
+}
+# ============================================================|
+def parse_metadata(app_metadata: AppMetadata) -> Dict[str, Union[str, float, int, bool, dict]]:
+    """Separate argparser for runtime parameters,
+
+    uses parameters accessible via `metadata.py` to
+    construct the argparse arguments, parses them,
+    and converts them to a dictionary of values before returning
+    """
+
+    # helper function for argparse 'nargs' field
+    def _get_nargs(param):
+        if param.multivalued:
+            return "?" if param.type == "boolean" else "+"
+        return 1
+
+    parser = argparse.ArgumentParser(add_help=False,
+        description="Command-Line Interface for CLAMS app"
+    )
+
+    # keep track of dict-type values in parameters for later parsing
+    maps = set()
+
+    # parse cli args from app parameters
+    for parameter in app_metadata["parameters"]:
+        if type_map[parameter.type] == dict:
+            maps.add(parameter.name)
+        parser.add_argument(
+            f"--{parameter.name}",
+            help=parameter.description,
+            nargs=_get_nargs(parameter),
+            type=type_map[parameter.type],
+            choices=parameter.choices,
+            default=parameter.default,
+            action="store",
+        )
+
+    # namespace -> dictionary
+    app_args = vars(parser.parse_args())
+
+    # convert dict-type arg strings into k/v pairs
+    for arg, val in app_args.items():
+        if arg in maps:
+            app_args[arg] = {k: v for k, v in [pair.split(":") for pair in val]}
+
+    return app_args
+
+
+def main():
+    # CLI pipeline: `stdin` -> app._annotate -> `stdout`
+    input = sys.stdin
+
+    # Load data from stdin 
+    in_data = Mmif("".join([line.rstrip("\n") for line in input]))
+
+    # Load app from `app.py` constructor and get runtime params
+    clamsapp: ClamsApp = get_app()
+    app_metadata = dict(json.loads(clamsapp.appmetadata()))
+    runtime_parameters = parse_metadata(app_metadata=app_metadata)
+
+    # Write _annotate output (mmif) to stdout
+    print(clamsapp._annotate(in_data, **runtime_parameters), file=sys.stdout)
+
+if __name__ == "__main__":
+    main()

--- a/clams/develop/templates/app/cli.py.template
+++ b/clams/develop/templates/app/cli.py.template
@@ -10,6 +10,8 @@ import sys
 from contextlib import redirect_stdout
 
 import app
+
+import clams.app
 from clams import AppMetadata
 
 
@@ -24,23 +26,31 @@ def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
 
     # parse cli args from app parameters
     for parameter in app_metadata.parameters:
-        a = parser.add_argument(
-            f"--{parameter.name}",
-            help=parameter.description,
-            nargs=1,
-            action="store",
-            type=str)
+        if parameter.multivalued:
+            a = parser.add_argument(
+                f"--{parameter.name}",
+                help=parameter.description,
+                nargs='+',
+                action='extend',
+                type=str
+            )
+        else:
+            a = parser.add_argument(
+                f"--{parameter.name}",
+                help=parameter.description,
+                nargs=1,
+                action="store",
+                type=str)
         if parameter.choices is not None:
             a.choices = parameter.choices
         if parameter.default is not None:
-            a.help += f" (default: {parameter.default})"
+            a.help += f" (default: {parameter.default}"
+            if parameter.type == "boolean":
+                a.help += (f", any value except for {[v for v in clams.app.falsy_values if isinstance(v, str)]} "
+                           f"will be interpreted as True")
+            a.help += ')'
             # then we don't have to add default values to the arg_parser
             # since that's handled by the app._refined_params() method.
-        if parameter.multivalued:
-            a.nargs = '+'
-        if parameter.type == "boolean":
-            a.nargs = '?'
-            a.action = "store_true"
     parser.add_argument('IN_MMIF_FILE', nargs='?', type=argparse.FileType('r'),
                         help='input MMIF file path, or STDIN if `-` or not provided. NOTE: When running this cli.py in '
                              'a containerized environment, make sure the container is run with `-i` flag to keep stdin '

--- a/clams/restify/__init__.py
+++ b/clams/restify/__init__.py
@@ -143,6 +143,7 @@ class ClamsHTTPApi(Resource):
         try:
             return self.json_to_response(self.cla.annotate(raw_data, **raw_params))
         except Exception:
+            self.cla.logger.exception("Error in annotation")
             return self.json_to_response(self.cla.record_error(raw_data, **raw_params).serialize(pretty=True), status=500)
 
     put = post

--- a/documentation/clamsapp.md
+++ b/documentation/clamsapp.md
@@ -8,9 +8,9 @@ hence it's advised also to look up the app website (or code repository) to get t
 
 Generally, a CLAMS App requires 
 
+- To run the app in a container (as an HTTP server), container management software such as `docker` or `podman`. This is the recommended way to use CLAMS Apps.
+  - (the CLAMS team is using `docker` for development and testing, hence the instructions are based on `docker` commands.)
 - To run the app locally, Python3 with the `clams-python` module installed. Python 3.8 or higher is required.
-- To run the app in a container (as an HTTP server), container management software such as `docker` or `podman`.
-  - (the CLAMS team is using `docker` for development and testing)
 - To invoke and execute analysis, HTTP client utility (such as `curl`).
 
 For Python dependencies, usually CLAMS Apps come with `requirements.txt` files that list up the Python library. 
@@ -18,7 +18,7 @@ However, there could be other non-Python software/library that are required by t
 
 ### Installation
 
-CLAMS Apps available on the CLAMS App Directory. Currently all CLAMS Apps are open-source projects and are distributed as
+CLAMS Apps available on the CLAMS App Directory. Currently, all CLAMS Apps are open-source projects and are distributed as
 
 1. source code downloadable from code repository
 2. pre-built container image 
@@ -30,7 +30,7 @@ In most cases, you can "install" a CLAMS App by either
 1. downloading source code from the app code repository and manually building a container image
 2. downloading pre-built container image directly
 
-#### Build image from source code
+#### Build an image from source code
 
 To download the source code, you can either use `git clone` command or download a zip file from the source code repository. 
 The source code repository address can be found on the App Directory entry of the app.
@@ -40,7 +40,7 @@ From the locally downloaded project directory, run the following in your termina
 (Assuming you are using `docker` as your container manager)
 
 ```bash
-docker build . -f Containerfile -t <image_name_you_pick>
+$ docker build . -f Containerfile -t <IMAGE_NAME_YOU_PICK>
 ```
 
 #### Download prebuilt image
@@ -48,23 +48,25 @@ docker build . -f Containerfile -t <image_name_you_pick>
 Alternatively, the app maybe already be available on a container registry.
 
 ``` bash 
-docker pull <prebulit_image_name>
+$ docker pull <PREBULIT_IMAGE_NAME>
 ```
 
 The image name can be found on the App Directory entry of the app.
 
-### Running CLAMS App
+### Using CLAMS App
 
+CLAMS Apps are primarily designed to run as an HTTP server, but some apps written based on `clams-python` SDK additionally provide CLI equivalent to the HTTP requests. 
+In this session, we will first cover the usage of CLAMS apps as an HTTP server, and then cover the (optional) CLI.
 
-#### Running as a container
+#### Starting the HTTP server as a container
 
-Once the image is built (by `build`) or downloaded (by `pull`), to create a container, run:
+Once the image is built (by `docker build`) or downloaded (by `docker pull`), to create and start a container, run:
 
 ```bash
-docker run -v /path/to/data/directory:/data -p <port>:5000 <image_name>
+$ docker run -v /path/to/data/directory:/data -p <PORT>:5000 <IMAGE_NAME>
 ```
 
-where `/path/to/data/directory` is the local location of your media files or MMIF objects and `<port>` is the *host* port number you want your container to be listening to. 
+where `/path/to/data/directory` is the local location of your media files or MMIF objects and `PORT` is the *host* port number you want your container to be listening to. 
 The HTTP inside the container will be listening to 5000 by default. Usually any number above 1024 is fine for the host port number, and you can use the same 5000 number for the host port number.
 
 > **Note**
@@ -76,35 +78,18 @@ The HTTP inside the container will be listening to 5000 by default. Usually any 
 > ```
 > The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 > ```
-> This is because the image you are trying to run is built for Intel/AMC CPUs. To force the container to run on an emulation layer, you can add `--platform linux/amd64` option to the `docker run` command.
+> This is because the image you are trying to run is built for Intel/AMD x64 CPUs. To force the container to run on an emulation layer, you can add `--platform linux/amd64` option to the `docker run` command.
 
-
-#### Running as a local HTTP server
-
-To run the app as a local HTTP server without containerization, you can run the following command from the source code directory.
-
-```bash
-python app.py 
-```
-
-* By default, a CLAMS App will be listening to port 5000, but you can change the port number by passing `--port <number>` option. 
-* Be default, the app will be running in *debugging* mode, but you can change it to *production* mode by passing `--production` option to support larger traffic volume.
-
-#### Running as a CLI program
-
-(Not all CLAMS Apps can be run as a CLI program)
-
-Many CLAMS Apps are written to work as a CLI-based Python Program, although they are primarily designed to be run as an HTTP server.
-CLI-based execution is useful for testing and debugging purposes, and varies from app to app.
-To see the command line interface, please visit the app source code repository and look for additional instructions from the app developer.
 
 ### Invoking the app server
 
-#### App metadata
+#### To get app metadata
 
-Once the app is running as an HTTP server, visit the server address ([localhost:5000](http://localhost:5000))to get the app metadata. App metadata is also available at the App Directory entry of the app. App metadata contains important information about the app that we will use in the following sections.
+Once the app is running as an HTTP server, visit the server address ([localhost:5000](http://localhost:5000), or the remote host name if running on a remote computer) to get the app metadata. 
+App metadata is also available at the App Directory entry of the app if the app is published on the App Directory. 
+App metadata contains important information about the app that we will use in the following sections.
 
-#### Processing input media
+#### To process input media
 
 To actually run the app and process input media through computational analysis, simply send a POST request to the app with a MMIF input as the request body.
 
@@ -112,14 +97,14 @@ MMIF input files can be obtained from outputs of other CLAMS apps, or you can cr
 (Make sure you have installed [`clams-python` package](https://pypi.org/project/clams-python/) version from PyPI.)
 
 ```bash
-pip install clams-python
-clams source --help
+$ pip install clams-python
+$ clams source --help
 ```
 
 For example; by running 
 
 ```bash 
-clams source audio:/data/audio/some-audio-file.mp3
+$ clams source audio:/data/audio/some-audio-file.mp3
 ```
 
 You will get
@@ -143,7 +128,8 @@ You will get
 }
 ```
 
-If an app requires just `Document` inputs (see `input` section of the app metadata), an empty MMIF with required media file locations will suffice. The location has to be a URL or an absolute path, and it is important to ensure that it exists.
+If an app requires just `Document` inputs (see `input` section of the app metadata), an empty MMIF with required media file locations will suffice. 
+The location has to be a URL or an absolute path, and it is important to ensure that it exists.
 
 However, some apps only works with input MMIF that already contains some annotations of specific types. To run such apps, you need to run different apps in a sequence. 
 
@@ -153,15 +139,97 @@ When an input MMIF is ready, you can send it to the app server.
 Here's an example of how to use the `curl` command, and store the response in a file `output.mmif`.
 
 ```bash
-curl -H "Accept: application/json" -X POST -d@input.mmif -s http://localhost:5000 > output.mmif
+$ clams source audio:/data/audio/some-audio-file.mp3 > input.mmif
+$ curl -H "Accept: application/json" -X POST -d@input.mmif -s http://localhost:5000 > output.mmif
 
 # or using a bash pipeline 
-clams source audio:/data/audio/some-audio-file.mp3 | curl -X POST -d@- -s http://localhost:5000 > output.mmif
+$ clams source audio:/data/audio/some-audio-file.mp3 | curl -X POST -d@- -s http://localhost:5000 > output.mmif
 ```
-Appending `?pretty=True` to the URL will result in a pretty printed output. Note that when you're using `curl` from a shell session, you need to escape the `?` or `&` characters with `\` to prevent the shell from interpreting it as a special character.
 
 #### Configuring the app
 
 Running as an HTTP server, CLAMS Apps are stateless, but can be configured for each HTTP request by providing configuration parameters as [query string](https://en.wikipedia.org/wiki/Query_string). 
 
-For configuration parameters, please look for `parameter` section of the app metadata.
+For example, appending `?pretty=True` to the URL will result in a JSON output with indentation for better readability.
+
+> **Note**
+> When you're using `curl` from a shell session, you need to escape the `?` or `&` characters with `\` to prevent the shell from interpreting it as a special character.
+ 
+Different apps have different configurability. For configuration parameters of an app, please refer to `parameter` section of the app metadata.
+
+### Using CLAMS App as a CLI program
+
+First and foremost, not all CLAMS Apps support command line interface (CLI).
+At the minimum, a CLAMS app is required to support HTTP interfaces described in the previous section.
+If any of the following instructions do not work for an app, it is likely that the app does not support CLI. 
+
+#### Python entry points 
+
+Apps written on `clams-python` SDK have three python entry points by default: `app.py`, `metadata.py`, and `cli.py`.
+
+#### `app.py`: Running app as a local HTTP server
+
+`app.py` is the main entry point for running the app as an HTTP server. 
+To run the app as a local HTTP server without containerization, you can run the following command from the source code directory.
+
+```bash
+$ python app.py 
+```
+
+* By default, the app will be listening to port 5000, but you can change the port number by passing `--port <NUMBER>` option.
+* Be default, the app will be running in *debugging* mode, but you can change it to *production* mode by passing `--production` option to support larger traffic volume.
+* As you might have noticed, the default `CMD` in the prebuilt containers is `python app.py --production --port 5000`.
+
+#### `metadata.py`: Getting app metadata
+
+Running `metadata.py` will print out the app metadata in JSON format. 
+
+#### `cli.py`: Running as a CLI program
+
+`cli.py` is completely optional for app developers, and unlike the other two above that are guaranteed to be available, `cli.py` may not be available for some apps.
+When running an app as a HTTP app, the input MMIF must be passed as POST request's body, and the output MMIF will be returned as the response body.
+To mimic this behavior in a CLI, `cli.py` has two positional arguments; 
+
+``` bash 
+$ python cli.py <INPUT_MMIF> <OUTPUT_MMIF>  # will read INPUT_MMIF file, process it, and write the result to OUTPUT_MMIF file
+```
+
+`<INPUT_MMIF>` and `<OUTPUT_MMIF>` are file paths to the input and output MMIF files, respectively. 
+Following the common unix CLI practice, you can use `-` to represent STDIN and/or STDOUT
+
+``` bash
+# will read from STDIN, process it, and write the result to STDOUT
+$ python cli.py - -  
+
+# or equivalently
+$ python cli.py 
+
+# read from a file, write to STDOUT
+$ python cli.py input.mmif -
+
+# or equivalently
+$ python cli.py input.mmif
+
+# read from STDIN, write to a file
+$ cat input.mmif | python cli.py - output.mmif
+```
+
+As with the HTTP server, you can pass configuration parameters to the CLI program. 
+All parameter names are the same as the HTTP query parameters, but you need to use `--` prefix to indicate that it is a parameter.
+
+``` bash
+$ python cli.py --pretty True input.mmif output.mmif
+```
+
+Finally, when running the app as a container, you can override the default `CMD` (`app.py`) by passing a `cli.py` command to the `docker run` command.
+
+``` bash
+$ cat input.mmif | docker run -i -v /path/to/data/directory:/data <IMAGE_NAME> python cli.py 
+```
+
+Note that `input.mmif` is in the host machine, and the container is reading it from the STDIN. 
+You can also pass the input MMIF file as a volume to the container. 
+However, when you do so, you need to make sure that the file path in the MMIF is correctly set to the file path in the container.
+
+> **Note**
+> Here, make sure to pass [`-i` option to the `docker run`](https://docs.docker.com/reference/cli/docker/container/run/#interactive) command to make host's STDIN work properly with the container. 


### PR DESCRIPTION
This PR addresses #198 , by adding a "cli.py" template to the clams SDK. This script iterates over the "parameters" in a new app's metadata and parses them into argparse arguments. From here, it collects those arguments and stdin, runs `app._annotate()` , and produces the result to stdout

### Review

Generally, I think the areas that I'm least sure about:
- Safer / more idiomatic access to stdin / stdout
- I didn't add the template to any scripts, if that's something needed