### PR TITLE
when creating an "error view", only "raw" parameters are recodred in the view metadata

### DIFF
--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -260,7 +260,7 @@ class ClamsApp(ABC):
                 break
         if error_view is None:
             error_view = mmif.new_view()
-            self.sign_view(error_view, self._refine_params(**runtime_conf))
+            self.sign_view(error_view, runtime_conf)
         exc_info = sys.exc_info()
         error_view.set_error(f'{exc_info[0]}: {exc_info[1]}',
                              '\t\n'.join(traceback.format_tb(exc_info[2])))


### PR DESCRIPTION
fixes #232. 