### PR TITLE
added runningtime and hwinfo recorder (as universal params)

### DIFF
--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -158,8 +158,6 @@ class ClamsApp(ABC):
         runningTime = refined.get('runningTime', False)
         hwFetch = refined.get('hwFetch', False)
         runtime_recs = {}
-        if runningTime:
-            runtime_recs['runningTime'] = str(td)
         if hwFetch:
             import platform, shutil, subprocess
             runtime_recs['architecture'] = platform.machine()
@@ -170,10 +168,13 @@ class ClamsApp(ABC):
                                           stdout=subprocess.PIPE).stdout.decode('utf-8').strip().split('\n'):
                     name, mem = gpu.split(', ')
                     runtime_recs['cuda'].append(f'{name} ({mem})')
-        if len(runtime_recs) > 0:
-            for annotated_view in annotated.views:
-                if annotated_view.metadata.app == self.metadata.identifier:
-                    annotated_view.metadata.set_additional_property('runtime', runtime_recs)
+        for annotated_view in annotated.views:
+            if annotated_view.metadata.app == self.metadata.identifier:
+                if runningTime:
+                    annotated_view.metadata.set_additional_property('appRunningTime', str(td))
+                if len(runtime_recs) > 0:
+                    annotated_view.metadata.set_additional_property('appRunningHardware', runtime_recs)
+                    
         return annotated.serialize(pretty=pretty, sanitize=True)
 
     @abstractmethod

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -253,14 +253,14 @@ class TestClamsApp(unittest.TestCase):
         args3 = {'undefined_param1': ['value1']} 
         self.app.sign_view(v3, self.app._refine_params(**args3))
         self.assertEqual(len(v3.metadata.parameters), 1)
-        self.assertEqual(len(v3.metadata.appConfiguration), 3)  # universal (pretty) + `raise_error` in metadata.py + `multivalued_param`
+        self.assertEqual(len(v3.metadata.appConfiguration), 5)  # universal (pretty, runningtime, hwfetch) + `raise_error` in metadata.py + `multivalued_param`
         self.assertEqual(v3.metadata.appConfiguration['multivalued_param'], [])
         v4 = m.new_view()
         multiple_values = ['value1', 'value2']
         args4 = {'multivalued_param': multiple_values}
         self.app.sign_view(v4, self.app._refine_params(**args4))
         self.assertEqual(len(v4.metadata.parameters), 1)
-        self.assertEqual(len(v4.metadata.appConfiguration), 3)
+        self.assertEqual(len(v4.metadata.appConfiguration), 5)
         self.assertEqual(len(v4.metadata.parameters['multivalued_param']), len(str(multiple_values)))
 
     def test_annotate(self):


### PR DESCRIPTION
addresses #236 

Sample output; 

``` json 
  "views": [                                                                                                                                 
    {
      "id": "v_0",
      "metadata": {
        "runtime": {
          "runningTime": "0:00:05.466913",    # runningTime=True
          "architecture": "x86_64",           # hwFetch=True
          "cuda": [
            "NVIDIA RTX A6000 (49140 MiB)",
            "NVIDIA RTX A6000 (49140 MiB)",
            "NVIDIA RTX A6000 (49140 MiB)",
            "NVIDIA RTX A6000 (49140 MiB)"
          ]
        },
        "timestamp": "2024-07-05T21:00:07.408801",
        "app": "http://apps.clams.ai/swt-detection/v5.1-9-g6b12498",
        "contains": {
          "http://mmif.clams.ai/vocabulary/TimePoint/v4": {
            ...
          },
          "http://mmif.clams.ai/vocabulary/TimeFrame/v5": {
            ...
          },
          "http://mmif.clams.ai/vocabulary/Annotation/v5": {
            ...
          }
        },
        "parameters": {
          "pretty": "",
          "stopAt": "120000",
          "hwFetch": "",
          "runningTime": ""
        },
        "appConfiguration": {
          ...
        }
      }
    }
  ]
```
