### PR TITLE
releasing 1.2.6

### DIFF
--- a/clams/app/__init__.py
+++ b/clams/app/__init__.py
@@ -142,7 +142,7 @@ class ClamsApp(ABC):
                 issued_warnings.extend(ws)
         if issued_warnings:
             warnings_view = annotated.new_view()
-            self.sign_view(warnings_view, runtime_params)
+            self.sign_view(warnings_view, refined)
             warnings_view.metadata.warnings = issued_warnings
         return annotated.serialize(pretty=pretty, sanitize=True)
 
@@ -260,7 +260,7 @@ class ClamsApp(ABC):
                 break
         if error_view is None:
             error_view = mmif.new_view()
-            self.sign_view(error_view, runtime_conf)
+            self.sign_view(error_view, self._refine_params(**runtime_conf))
         exc_info = sys.exc_info()
         error_view.set_error(f'{exc_info[0]}: {exc_info[1]}',
                              '\t\n'.join(traceback.format_tb(exc_info[2])))

--- a/clams/develop/templates/app/Containerfile.template
+++ b/clams/develop/templates/app/Containerfile.template
@@ -25,7 +25,7 @@ ENV HF_HOME="/cache/huggingface"
 # https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved
 ENV TORCH_HOME="/cache/torch"
 
-RUN mkdir /cache ; rm -rf /root/.cache && ln -s /cache /root/.cache
+RUN mkdir /cache ; rm -rf /root/.cache ; ln -s /cache /root/.cache
 ################################################################################
 
 ################################################################################

--- a/clams/develop/templates/app/Containerfile.template
+++ b/clams/develop/templates/app/Containerfile.template
@@ -25,7 +25,7 @@ ENV HF_HOME="/cache/huggingface"
 # https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved
 ENV TORCH_HOME="/cache/torch"
 
-RUN mkdir /cache && rm -rf /root/.cache && ln -s /cache /root/.cache
+RUN mkdir /cache ; rm -rf /root/.cache && ln -s /cache /root/.cache
 ################################################################################
 
 ################################################################################

--- a/container/opencv4.containerfile
+++ b/container/opencv4.containerfile
@@ -41,5 +41,5 @@ RUN make -j$(nproc) && make install && ldconfig
 WORKDIR /
 RUN rm -rf ${OPENCV_PATH} ${OPENCV_EXTRA_PATH}
 RUN pip uninstall opencv-python
-RUN pip install --no-cache-dir opencv-python~=${OPENCV_VERSION}
+RUN pip install --no-cache-dir opencv-python-headless~=${OPENCV_VERSION}
 RUN apt-get remove -y g++ cmake make wget unzip libavcodec-dev libavformat-dev libavutil-dev libswscale-dev && apt-get autoremove -y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.15
+mmif-python==1.0.16
 
 Flask>=2
 Flask-RESTful>=0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.17
+mmif-python==1.0.18
 
 Flask>=2
 Flask-RESTful>=0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.16
+mmif-python==1.0.17
 
 Flask>=2
 Flask-RESTful>=0.3.9

--- a/tests/test_clamsapp.py
+++ b/tests/test_clamsapp.py
@@ -10,6 +10,7 @@ from typing import Union
 import jsonschema
 import pytest
 from mmif import Mmif, Document, DocumentTypes, AnnotationTypes, View, __specver__
+from mmif.serialize.mmif import ViewsList
 
 import clams.app
 import clams.restify
@@ -352,14 +353,16 @@ class TestClamsApp(unittest.TestCase):
             self.app._refine_params(param1=['p1'], param4=['4'])
             
     def test_error_handling(self):
-        params = {'raise_error': 'true', 'pretty': 'true'}
+        params = {'raise_error': ['true'], 'pretty': ['true']}
         in_mmif = Mmif(self.in_mmif)
         try: 
             out_mmif = self.app.annotate(in_mmif, **params)
         except Exception as e:
             out_mmif_from_str = self.app.set_error_view(self.in_mmif, **params)
             out_mmif_from_mmif = self.app.set_error_view(in_mmif, **params)
-            self.assertEqual(out_mmif_from_mmif.views, out_mmif_from_str.views)
+            self.assertEqual(
+                out_mmif_from_mmif.views.get_last(),
+                out_mmif_from_str.views.get_last())
             out_mmif = out_mmif_from_str
         self.assertIsNotNone(out_mmif)
         last_view: View = next(reversed(out_mmif.views))


### PR DESCRIPTION
### Overview
Patch release to update mmif SDK version, and minor improvements

### Additions
- `clams source --help` will display formatting guidelines for docloc plugins, if provided by the plugin developer (https://github.com/clamsproject/clams-python/issues/235)

### Changes
- now based on `mmif-python` 1.0.18
- bug fix "raw" runtime parameters weren't properly recorded when an app fails to refine the parameters (https://github.com/clamsproject/clams-python/issues/232) 
