### PR TITLE
releasing 1.3.0

### DIFF
--- a/clams/develop/templates/app/Containerfile.template
+++ b/clams/develop/templates/app/Containerfile.template
@@ -25,7 +25,7 @@ ENV HF_HOME="/cache/huggingface"
 # https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved
 ENV TORCH_HOME="/cache/torch"
 
-RUN mkdir /cache ; rm -rf /root/.cache && ln -s /cache /root/.cache
+RUN mkdir /cache ; rm -rf /root/.cache ; ln -s /cache /root/.cache
 ################################################################################
 
 ################################################################################

--- a/container/opencv4.containerfile
+++ b/container/opencv4.containerfile
@@ -41,5 +41,5 @@ RUN make -j$(nproc) && make install && ldconfig
 WORKDIR /
 RUN rm -rf ${OPENCV_PATH} ${OPENCV_EXTRA_PATH}
 RUN pip uninstall opencv-python
-RUN pip install --no-cache-dir opencv-python~=${OPENCV_VERSION}
+RUN pip install --no-cache-dir opencv-python-headless~=${OPENCV_VERSION}
 RUN apt-get remove -y g++ cmake make wget unzip libavcodec-dev libavformat-dev libavutil-dev libswscale-dev && apt-get autoremove -y

--- a/documentation/appmetadata.rst
+++ b/documentation/appmetadata.rst
@@ -91,7 +91,7 @@ input specification can be as simple as the following:
       # and more app metadata fields, 
     }
     
-In the above example, the developer is declaring the app is expecting ``Token``annotation objects, with a ``posTagSet`` 
+In the above example, the developer is declaring the app is expecting ``Token`` annotation objects, with a ``posTagSet`` 
 property of which value is the URL of the Penn Treebank POS tag set, *verbatim*, in the input MMIF, and all other 
 existing annotation types in the input MMIF will be ignored during processing. There are some *grammar* of how this 
 ``input`` list can be written. 

--- a/documentation/autodoc/clams.appmetadata.rst
+++ b/documentation/autodoc/clams.appmetadata.rst
@@ -6,3 +6,15 @@ Module contents
 
 .. autoclass:: clams.appmetadata.AppMetadata
    :members:
+
+.. autoclass:: clams.appmetadata.Input
+   :members:
+   :inherited-members:
+
+.. autoclass:: clams.appmetadata.Output
+   :members:
+   :inherited-members:
+
+.. autoclass:: clams.appmetadata.RuntimeParameter
+   :members:
+   :inherited-members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mmif-python==1.0.17
+mmif-python==1.0.18
 
 Flask>=2
 Flask-RESTful>=0.3.9


### PR DESCRIPTION
### Overview
This version added two universal runtime parameters that make some aspects of the runtime environment are recorded in the views' metadata. 


### Additions
- `hwFetch` universal parameter will record CPU architecture and CUDA devices in `view.metadata.appRunningHardware` 
- `runningTime` universal parameter will record app's running time in `view.metadata.appRunningTime`
- See https://github.com/clamsproject/clams-python/issues/236 for rationale behind 

